### PR TITLE
Override image-builder repo used for image publish workflow for now

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -27,7 +27,10 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2.3.4
       with:
-        repository: kubernetes-sigs/image-builder
+        # Overriding upstream until https://github.com/kubernetes-sigs/image-builder/pull/697 merges
+        #repository: kubernetes-sigs/image-builder
+        repository: detiber/image-builder
+        ref: bumpUbuntuISO
         path: image-builder
     - name: Install QEMU
       run: |


### PR DESCRIPTION
## Description

Override the repo/branch used for image-builder until upstream is fixed

## Why is this needed

Upstream is currently broken pending https://github.com/kubernetes-sigs/image-builder/pull/697 merging
