### PR TITLE
Use new upstream published images, revert kube-vip daemonset to static pods

### DIFF
--- a/api/v1alpha4/tinkerbellcluster_types.go
+++ b/api/v1alpha4/tinkerbellcluster_types.go
@@ -55,11 +55,13 @@ type TinkerbellClusterSpec struct {
 	// ImageLookupBaseRegistry is the base Registry URL that is used for pulling images,
 	// if not set, the default will be to use $TINKERBELL_IP.
 	// +optional
+	// +kubebuilder:default=ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
 	ImageLookupBaseRegistry string `json:"imageLookupBaseRegistry,omitempty"`
 
 	// ImageLookupOSDistro is the name of the OS distro to use when fetching machine images,
 	// if not set it will default to ubuntu.
 	// +optional
+	// +kubebuilder:default=ubuntu
 	ImageLookupOSDistro string `json:"imageLookupOSDistro,omitempty"`
 
 	// ImageLookupOSVersion is the version of the OS distribution to use when fetching machine

--- a/api/v1alpha4/tinkerbellcluster_webhook.go
+++ b/api/v1alpha4/tinkerbellcluster_webhook.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha4
 
 import (
-	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,7 +26,6 @@ import (
 const (
 	osUbuntu             = "ubuntu"
 	defaultUbuntuVersion = "20.04"
-	defaultOSDistro      = osUbuntu
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
@@ -65,14 +63,6 @@ func defaultVersionForOSDistro(distro string) string {
 func (c *TinkerbellCluster) Default() {
 	if c.Spec.ImageLookupFormat == "" {
 		c.Spec.ImageLookupFormat = "{{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz"
-	}
-
-	if c.Spec.ImageLookupBaseRegistry == "" {
-		c.Spec.ImageLookupBaseRegistry = os.Getenv("TINKERBELL_IP")
-	}
-
-	if c.Spec.ImageLookupOSDistro == "" {
-		c.Spec.ImageLookupOSDistro = defaultOSDistro
 	}
 
 	if c.Spec.ImageLookupOSVersion == "" {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellclusters.yaml
@@ -64,6 +64,7 @@ spec:
                 - port
                 type: object
               imageLookupBaseRegistry:
+                default: ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
                 description: ImageLookupBaseRegistry is the base Registry URL that
                   is used for pulling images, if not set, the default will be to use
                   $TINKERBELL_IP.
@@ -85,6 +86,7 @@ spec:
                   will attempt to pull the image from that location. See also: https://golang.org/pkg/text/template/'
                 type: string
               imageLookupOSDistro:
+                default: ubuntu
                 description: ImageLookupOSDistro is the name of the OS distro to use
                   when fetching machine images, if not set it will default to ubuntu.
                 type: string

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -13,9 +13,7 @@ spec:
   kubeadmConfigSpec:
     preKubeadmCommands:
       - echo "127.0.1.1 {{ ds.meta_data.hostname }}" >> /etc/hosts
-      - if [ -f "/run/kubeadm/kubeadm.yaml" ]; then mkdir -p /etc/kubernetes/manifests && ctr images pull ghcr.io/kube-vip/kube-vip:v0.3.8 && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v0.3.8 vip /kube-vip manifest pod --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address ${CONTROL_PLANE_VIP} --controlplane --leaderElection > /etc/kubernetes/manifests/kube-vip.yaml; fi
-    postKubeadmCommands:
-      - 'if [ -f "/run/kubeadm/kubeadm.yaml" ]; then kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://kube-vip.io/manifests/rbac.yaml && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v0.3.8 vip /kube-vip manifest daemonset --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address ${CONTROL_PLANE_VIP} --controlplane --leaderElection --inCluster --taint | kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f - && rm /etc/kubernetes/manifests/kube-vip.yaml; fi'
+      - mkdir -p /etc/kubernetes/manifests && ctr images pull ghcr.io/kube-vip/kube-vip:v0.3.8 && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v0.3.8 vip /kube-vip manifest pod --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address ${CONTROL_PLANE_VIP} --controlplane --leaderElection > /etc/kubernetes/manifests/kube-vip.yaml
     # initConfiguration and joinConfiguration must be in sync to have the same features
     # for both cluster bootstrapping and new controller nodes joining.
     #
@@ -31,6 +29,8 @@ spec:
     clusterConfiguration: {}
     joinConfiguration:
       nodeRegistration:
+        ignorePreflightErrors:
+          - DirAvailable--etc-kubernetes-manifests
         kubeletExtraArgs:
           # This field is replaced by controller when rendering cloud-init config
           # until we have Tinkerbell CCM.


### PR DESCRIPTION
## Description

Use the newly published upstream image-builder based images by default.

Switch to kube-vip static pods, the daemonset was causing issues with upgrading a KCP with only 1 replica.

