### PR TITLE
Use TINKERBELL_IP to determine metadata url

### DIFF
--- a/api/v1alpha4/tinkerbellcluster_types.go
+++ b/api/v1alpha4/tinkerbellcluster_types.go
@@ -42,7 +42,7 @@ type TinkerbellClusterSpec struct {
 	// unless a machine specifies a different ImageLookupFormat. Supports substitutions
 	// for {{.BaseRegistry}}, {{.OSDistro}}, {{.OSVersion}} and {{.KubernetesVersion}} with
 	// the basse URL, OS distribution, OS version, and kubernetes version, respectively.
-	// BaseRegistry will be the value in ImageLookupBaseRegistry or $TINKERBELL_IP
+	// BaseRegistry will be the value in ImageLookupBaseRegistry or ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
 	// (the default), OSDistro will be the value in ImageLookupOSDistro or ubuntu (the default),
 	// OSVersion will be the value in ImageLookupOSVersion or default based on the OSDistro
 	// (if known), and the kubernetes version as defined by the packages produced by
@@ -53,7 +53,7 @@ type TinkerbellClusterSpec struct {
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 
 	// ImageLookupBaseRegistry is the base Registry URL that is used for pulling images,
-	// if not set, the default will be to use $TINKERBELL_IP.
+	// if not set, the default will be to use ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.
 	// +optional
 	// +kubebuilder:default=ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
 	ImageLookupBaseRegistry string `json:"imageLookupBaseRegistry,omitempty"`

--- a/api/v1alpha4/tinkerbellmachine_types.go
+++ b/api/v1alpha4/tinkerbellmachine_types.go
@@ -35,7 +35,7 @@ type TinkerbellMachineSpec struct {
 	// unless a machine specifies a different ImageLookupFormat. Supports substitutions
 	// for {{.BaseRegistry}}, {{.OSDistro}}, {{.OSVersion}} and {{.KubernetesVersion}} with
 	// the basse URL, OS distribution, OS version, and kubernetes version, respectively.
-	// BaseRegistry will be the value in ImageLookupBaseRegistry or $TINKERBELL_IP
+	// BaseRegistry will be the value in ImageLookupBaseRegistry or ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
 	// (the default), OSDistro will be the value in ImageLookupOSDistro or ubuntu (the default),
 	// OSVersion will be the value in ImageLookupOSVersion or default based on the OSDistro
 	// (if known), and the kubernetes version as defined by the packages produced by
@@ -46,7 +46,7 @@ type TinkerbellMachineSpec struct {
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 
 	// ImageLookupBaseRegistry is the base Registry URL that is used for pulling images,
-	// if not set, the default will be to use $TINKERBELL_IP.
+	// if not set, the default will be to use ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.
 	// +optional
 	ImageLookupBaseRegistry string `json:"imageLookupBaseRegistry,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellclusters.yaml
@@ -67,7 +67,7 @@ spec:
                 default: ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
                 description: ImageLookupBaseRegistry is the base Registry URL that
                   is used for pulling images, if not set, the default will be to use
-                  $TINKERBELL_IP.
+                  ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.
                 type: string
               imageLookupFormat:
                 description: 'ImageLookupFormat is the URL naming format to use for
@@ -77,12 +77,13 @@ spec:
                   {{.OSDistro}}, {{.OSVersion}} and {{.KubernetesVersion}} with the
                   basse URL, OS distribution, OS version, and kubernetes version,
                   respectively. BaseRegistry will be the value in ImageLookupBaseRegistry
-                  or $TINKERBELL_IP (the default), OSDistro will be the value in ImageLookupOSDistro
-                  or ubuntu (the default), OSVersion will be the value in ImageLookupOSVersion
-                  or default based on the OSDistro (if known), and the kubernetes
-                  version as defined by the packages produced by kubernetes/release:
-                  v1.13.0, v1.12.5-mybuild.1, or v1.17.3. For example, the default
-                  image format of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz
+                  or ghcr.io/tinkerbell/cluster-api-provider-tinkerbell (the default),
+                  OSDistro will be the value in ImageLookupOSDistro or ubuntu (the
+                  default), OSVersion will be the value in ImageLookupOSVersion or
+                  default based on the OSDistro (if known), and the kubernetes version
+                  as defined by the packages produced by kubernetes/release: v1.13.0,
+                  v1.12.5-mybuild.1, or v1.17.3. For example, the default image format
+                  of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz
                   will attempt to pull the image from that location. See also: https://golang.org/pkg/text/template/'
                 type: string
               imageLookupOSDistro:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -67,7 +67,7 @@ spec:
               imageLookupBaseRegistry:
                 description: ImageLookupBaseRegistry is the base Registry URL that
                   is used for pulling images, if not set, the default will be to use
-                  $TINKERBELL_IP.
+                  ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.
                 type: string
               imageLookupFormat:
                 description: 'ImageLookupFormat is the URL naming format to use for
@@ -77,12 +77,13 @@ spec:
                   {{.OSDistro}}, {{.OSVersion}} and {{.KubernetesVersion}} with the
                   basse URL, OS distribution, OS version, and kubernetes version,
                   respectively. BaseRegistry will be the value in ImageLookupBaseRegistry
-                  or $TINKERBELL_IP (the default), OSDistro will be the value in ImageLookupOSDistro
-                  or ubuntu (the default), OSVersion will be the value in ImageLookupOSVersion
-                  or default based on the OSDistro (if known), and the kubernetes
-                  version as defined by the packages produced by kubernetes/release:
-                  v1.13.0, v1.12.5-mybuild.1, or v1.17.3. For example, the default
-                  image format of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz
+                  or ghcr.io/tinkerbell/cluster-api-provider-tinkerbell (the default),
+                  OSDistro will be the value in ImageLookupOSDistro or ubuntu (the
+                  default), OSVersion will be the value in ImageLookupOSVersion or
+                  default based on the OSDistro (if known), and the kubernetes version
+                  as defined by the packages produced by kubernetes/release: v1.13.0,
+                  v1.12.5-mybuild.1, or v1.17.3. For example, the default image format
+                  of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz
                   will attempt to pull the image from that location. See also: https://golang.org/pkg/text/template/'
                 type: string
               imageLookupOSDistro:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
@@ -56,7 +56,7 @@ spec:
                       imageLookupBaseRegistry:
                         description: ImageLookupBaseRegistry is the base Registry
                           URL that is used for pulling images, if not set, the default
-                          will be to use $TINKERBELL_IP.
+                          will be to use ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.
                         type: string
                       imageLookupFormat:
                         description: 'ImageLookupFormat is the URL naming format to
@@ -66,7 +66,7 @@ spec:
                           substitutions for {{.BaseRegistry}}, {{.OSDistro}}, {{.OSVersion}}
                           and {{.KubernetesVersion}} with the basse URL, OS distribution,
                           OS version, and kubernetes version, respectively. BaseRegistry
-                          will be the value in ImageLookupBaseRegistry or $TINKERBELL_IP
+                          will be the value in ImageLookupBaseRegistry or ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
                           (the default), OSDistro will be the value in ImageLookupOSDistro
                           or ubuntu (the default), OSVersion will be the value in
                           ImageLookupOSVersion or default based on the OSDistro (if

--- a/controllers/machine.go
+++ b/controllers/machine.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"text/template"
@@ -180,8 +181,16 @@ func (mrc *machineReconcileContext) createTemplate(hardware *tinkv1.Hardware) er
 		return fmt.Errorf("failed to generate imageURL: %w", err)
 	}
 
+	metadataIP := os.Getenv("TINKERBELL_IP")
+	if metadataIP == "" {
+		metadataIP = "192.168.1.1"
+	}
+
+	metadataURL := fmt.Sprintf("http://%s:50061", metadataIP)
+
 	workflowTemplate := templates.WorkflowTemplate{
 		Name:          mrc.tinkerbellMachine.Name,
+		MetadataURL:   metadataURL,
 		ImageURL:      imageURL,
 		DestDisk:      targetDisk,
 		DestPartition: targetDevice,

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -33,6 +33,7 @@ var (
 // WorkflowTemplate is a helper struct for rendering CAPT Template data.
 type WorkflowTemplate struct {
 	Name          string
+	MetadataURL   string
 	ImageURL      string
 	DestDisk      string
 	DestPartition string
@@ -49,7 +50,7 @@ func (wt WorkflowTemplate) Render() (string, error) {
 	}
 
 	return fmt.Sprintf(workflowTemplate, wt.Name, wt.Name, wt.ImageURL, wt.DestDisk, wt.DestPartition,
-		wt.DestPartition, wt.DestPartition), nil
+		wt.MetadataURL, wt.DestPartition, wt.DestPartition), nil
 }
 
 const (
@@ -86,7 +87,7 @@ tasks:
           CONTENTS: |
             datasource:
               Ec2:
-                metadata_urls: ["http://169.254.169.254:50061"]
+                metadata_urls: ["%s"]
                 strict_id: false
             system_info:
               default_user:

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -28,6 +28,7 @@ import (
 func validWorkflowTemplate() *templates.WorkflowTemplate {
 	return &templates.WorkflowTemplate{
 		Name:          "foo",
+		MetadataURL:   "http://10.10.10.10",
 		ImageURL:      "http://foo.bar.baz/do/it",
 		DestDisk:      "/dev/sda",
 		DestPartition: "/dev/sda1",


### PR DESCRIPTION
## Description

link local address is not needed, since dhcp configuration of network is done before requesting metadata url

## Why is this needed

This fixes issues when tink and workers are deployed and the link local address does not resolve.

