### PR TITLE
Update docs and old repo references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We're so glad you're here.
 
 ### Important Resources
 
-#### bugs: [https://github.com/tinkerbell/cluster-api-provider-tink/issues](https://github.com/tinkerbell/cluster-api-provider-tink/issues)
+#### bugs: [https://github.com/tinkerbell/cluster-api-provider-tinkerbell/issues](https://github.com/tinkerbell/cluster-api-provider-tinkerbell/issues)
 
 ### Code of Conduct
 
@@ -17,16 +17,16 @@ Please read and understand the DCO found [here](docs/DCO.md).
 
 ### Environment Details
 
-[https://github.com/tinkerbell/cluster-api-provider-tink/blob/main/Makefile](https://github.com/tinkerbell/cluster-api-provider-tink/blob/main/Makefile)
+[https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/Makefile](https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/Makefile)
 
 ### How to Submit Change Requests
 
-Please submit change requests and / or features via [Issues](https://github.com/tinkerbell/cluster-api-provider-tink/issues).
+Please submit change requests and / or features via [Issues](https://github.com/tinkerbell/cluster-api-provider-tinkerbell/issues).
 There's no guarantee it'll be changed, but you never know until you try.
 We'll try to add comments as soon as possible, though.
 
 ### How to Report a Bug
 
-Bugs are problems in code, in the functionality of an application or in its UI design; you can submit them through [Issues](https://github.com/tinkerbell/cluster-api-provider-tink/issues).
+Bugs are problems in code, in the functionality of an application or in its UI design; you can submit them through [Issues](https://github.com/tinkerbell/cluster-api-provider-tinkerbell/issues).
 
 ## Code Style Guides

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Provider for Tinkerbell.
 7th December 2020 marks the first commit for this project, it starts as a
 porting from CAPP (cluster api provider packet).
 
-As it is now it is able to bootstrap single Control Plane instance clusters using hardware
-managed by Tinkerbell. Support for upgrades and multi-instance Control Plane clusters is
-still outstanding.
+Currently, it is possible to bootstrap both single instance and HA Control Plane workload 
+clusters using hardware managed by Tinkerbell.
+
+Integration with [PBnJ](https://github.com/tinkerbell/pbnj) for remote power management
+and secure deprovisioning of instances is still outstanding and must be handled externally.
 
 See [docs/README.md](docs/README.md) for more information on setting up a development
 environment.
@@ -40,6 +42,3 @@ This project is under active development and you should expect issues, pull
 requests and conversation ongoing in the [bi-weekly community
 meeting](https://github.com/tinkerbell/.github/blob/main/COMMUNICATION.md#contributors-mailing-list).
 Feel free to join if you are curious or if you have any question.
-
-There is a milestone called `v0.1.0 tech preview`. Have a look at issues
-assigned to that label to know more about what it will contain.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,8 @@ If you have Tinkerbell running in your environment, you can use it for CAPT.
 
 Here is the list of required components to use CAPT:
 
-- Existing Tinkerbell installation running at least versions mentioned in [sandbox](https://github.com/tinkerbell/sandbox/commit/8256ad1e8515c2a97a27091c0f5c12e42f083748), this guide assumes deployment using the sandbox with an IP address of 192.168.1.1, so modifications will be needed if Tinkerbell was deployed with a different method or if the IP address is different.
-  - This also assumes that the hegel port is exposed in your environment, if running a version of the sandbox prior to https://github.com/tinkerbell/sandbox/commit/8256ad1e8515c2a97a27091c0f5c12e42f083748, this will need to be done manually.
+- Existing Tinkerbell installation running at least versions mentioned in v0.6.0 of [sandbox](https://github.com/tinkerbell/sandbox/tree/v0.6.0), this guide assumes deployment using the sandbox with an IP address of 192.168.1.1, so modifications will be needed if Tinkerbell was deployed with a different method or if the IP address is different.
+  - This also assumes that the hegel port is exposed in your environment, if running a version of the sandbox prior to https://github.com/tinkerbell/sandbox/tree/v0.6.0, this will need to be done manually.
 - A Kubernetes cluster which pods has access to your Tinkerbell instance.
 - At least one Hardware available with DHCP IP address configured on first interface and with proper metadata configured
 - `git` binary
@@ -21,10 +21,6 @@ Required metadata for hardware:
 - metadata.instance.id is set (should match the hardware's id)
 - metadata.instance.hostname is set
 - metadata.instance.storage.disks is set and contains at least one device matching an available disk on the system
-
-### Add a link-local address for Hegel
-
-If your sandbox is running on an Ubuntu system, you can edit `/etc/netplan.<devicename>.yaml`, add `169.254.169.254/16` to the addresses, and run `netplan apply`
 
 ### Mirror the necessary Tinkerbell actions to the registry
 
@@ -56,7 +52,7 @@ kubectl config get-contexts  | awk '/^*/ {print $2}'
 Then, run the following commands to clone code we're going to run:
 ```sh
 git clone https://github.com/kubernetes-sigs/cluster-api -b release-0.4
-git clone git@github.com:tinkerbell/cluster-api-provider-tink.git
+git clone git@github.com:tinkerbell/cluster-api-provider-tinkerbell.git
 cd ../cluster-api
 ```
 
@@ -66,7 +62,7 @@ then replace placeholders with actual values:
 cat <<EOF > tilt-settings.json
 {
   "default_registry": "quay.io/<your username>",
-  "provider_repos": ["../cluster-api-provider-tink"],
+  "provider_repos": ["../cluster-api-provider-tinkerbell"],
   "enable_providers": ["tinkerbell", "kubeadm-bootstrap", "kubeadm-control-plane"],
   "allowed_contexts": ["<your kubeconfig context to use"],
   "kustomize_substitutions": {

--- a/tink/test/utils/generators.go
+++ b/tink/test/utils/generators.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package utils contains test utilities for cluster-api-provider-tink.
+// Package utils contains test utilities for cluster-api-provider-tinkerbell.
 package utils
 
 import (


### PR DESCRIPTION
## Description

- Update docs to reference latest sandbox release
- Remove old references to cluster-api-provider-tink instead of cluster-api-provider-tinkerbell

