### PR TITLE
Add release docs and update release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,12 +104,11 @@ jobs:
         REPO: ${{ github.event.repository.name }}
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        files: out/release/*
         body: ${{ env.RELEASE_NOTES }}
         draft: false
         prerelease: false

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,25 @@
+# Release
+
+This document describes how to release the Tinkerell infrastructure provider.
+
+This is _not_ intended for regular users.
+
+This is normally performed by our CI system. However, there are important steps to take first.
+
+## How to Cut a Release
+
+In order to cut a release, you must:
+
+1. If this is a new major or minor version - but **not** just a patch change - update [metadata.yaml](./metadata.yaml) to add it, and map it to the correct cluster-api contract version
+1. Commit the changes.
+1. Push out your branch, open a PR and merge the changes
+1. Wait for the Continuous Integration github action to finish running
+1. Tag the release with `git tag -a vX.Y.z -m "Message"
+1. Push out the tag
+
+## How A Release Happens
+
+* GitHub Actions detects a new tag has been pushed
+* CI builds docker images for each supported architecture as well as a multi-arch manifest, and tags it with the semver tag of the release, e.g. `v0.1.0`
+* CI creates the release in `out/release`, the equivalent of `make release`
+* CI copies the artifacts in `out/release/*` to the github releases


### PR DESCRIPTION
## Description

- Adds documentation around release
- Fixes release workflow to add artifacts

## Why is this needed

- Enables others to create releases
- Fixes manual step needed to add release artifacts for the v0.1.0 release.