### PR TITLE
Do an apt update before trying to install qemu for build workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -31,6 +31,7 @@ jobs:
         path: image-builder
     - name: Install QEMU
       run: |
+        sudo apt update
         sudo -i apt install qemu-system-x86
     - name: Build the images
       run: |


### PR DESCRIPTION
## Description

Do an apt update before trying to install qemu for build workflow

## Why is this needed

Without `apt update`, the attempt to install qemu fails because it's trying to install versions of dependencies that no longer exist.

