### PR TITLE
Use a known good version of image-builder for building images

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -29,6 +29,8 @@ jobs:
       with:
         repository: kubernetes-sigs/image-builder
         path: image-builder
+        # Workaround for breaking changes in upstream image-builder that need to be verified
+        ref: 9eea1153526d37969e96697cb1dacd15e28dbccf
     - name: Install QEMU
       run: |
         sudo apt update


### PR DESCRIPTION
## Description

Use a known good version of image-builder for building images

## Why is this needed

Latest HEAD of image-builder includes breaking changes that need to be verified. This allows us to continue building images before fully verifying the latest image-builder changes work with CAPT
