### PR TITLE
Add templateOverride field to override the default workflowTemplate

### DIFF
--- a/api/v1beta1/tinkerbellmachine_types.go
+++ b/api/v1beta1/tinkerbellmachine_types.go
@@ -60,6 +60,10 @@ type TinkerbellMachineSpec struct {
 	// +optional
 	ImageLookupOSVersion string `json:"imageLookupOSVersion,omitempty"`
 
+	// TemplateOverride overrides the default CAPT hardware template
+	// +optional
+	TemplateOverride string `json:"templateOverride,omitempty"`
+
 	// Those fields are set programmatically, but they cannot be re-constructed from "state of the world", so
 	// we put them in spec instead of status.
 	HardwareName string `json:"hardwareName,omitempty"`

--- a/api/v1beta1/tinkerbellmachine_types.go
+++ b/api/v1beta1/tinkerbellmachine_types.go
@@ -60,7 +60,8 @@ type TinkerbellMachineSpec struct {
 	// +optional
 	ImageLookupOSVersion string `json:"imageLookupOSVersion,omitempty"`
 
-	// TemplateOverride overrides the default CAPT hardware template
+	// TemplateOverride overrides the default Tinkerbell template used by CAPT.
+	// You can learn more about Tinkerbell templates here: https://docs.tinkerbell.org/templates/
 	// +optional
 	TemplateOverride string `json:"templateOverride,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -97,6 +97,10 @@ spec:
                 type: string
               providerID:
                 type: string
+              templateOverride:
+                description: TemplateOverride overrides the default CAPT hardware
+                  template
+                type: string
             type: object
           status:
             description: TinkerbellMachineStatus defines the observed state of TinkerbellMachine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -98,8 +98,9 @@ spec:
               providerID:
                 type: string
               templateOverride:
-                description: TemplateOverride overrides the default CAPT hardware
-                  template
+                description: 'TemplateOverride overrides the default Tinkerbell template
+                  used by CAPT. You can learn more about Tinkerbell templates here:
+                  https://docs.tinkerbell.org/templates/'
                 type: string
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
@@ -88,6 +88,10 @@ spec:
                         type: string
                       providerID:
                         type: string
+                      templateOverride:
+                        description: TemplateOverride overrides the default CAPT hardware
+                          template
+                        type: string
                     type: object
                 required:
                 - spec

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
@@ -89,8 +89,9 @@ spec:
                       providerID:
                         type: string
                       templateOverride:
-                        description: TemplateOverride overrides the default CAPT hardware
-                          template
+                        description: 'TemplateOverride overrides the default Tinkerbell
+                          template used by CAPT. You can learn more about Tinkerbell
+                          templates here: https://docs.tinkerbell.org/templates/'
                         type: string
                     type: object
                 required:

--- a/controllers/machine.go
+++ b/controllers/machine.go
@@ -169,12 +169,12 @@ func (mrc *machineReconcileContext) imageURL() (string, error) {
 }
 
 func (mrc *machineReconcileContext) createTemplate(hardware *tinkv1.Hardware) error {
+	if len(hardware.Status.Disks) < 1 {
+		return ErrHardwareMissingDiskConfiguration
+	}
+
 	templateData := mrc.tinkerbellMachine.Spec.TemplateOverride
 	if templateData == "" {
-		if len(hardware.Status.Disks) < 1 {
-			return ErrHardwareMissingDiskConfiguration
-		}
-
 		targetDisk := hardware.Status.Disks[0].Device
 		targetDevice := firstPartitionFromDevice(targetDisk)
 


### PR DESCRIPTION
## Description
This PR adds a new field `templateOverride` to TinkerbellMachine CRD to override the default CAPT workflow template https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/internal/templates/templates.go#L56-L122

## Why is this needed
Currently, the workflow template for Tinkerbell machines is hardcoded and there isn't a way to provide a custom template. If a user wants to provide a customized template with different actions, CAPT currently doesn't provide a way to do that.

## How Has This Been Tested?
Tested the changes by passing a custom template using the templateOverride field and verified that the custom template works properly and provisions a CAPT cluster. 
I tested the changes on bare-metal nodes and added some custom actions along with the [default ones](https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/internal/templates/templates.go#L56-L122) in the template. 

## How are existing users impacted? What migration steps/scripts do we need?
This change doesn't impact existing users. The `templateOverride` field is optional and if a user doesn't specify it, the default CAPT template is used instead.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
