### PR TITLE
mergify: Add each matrix permutation as a check-success requirement

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,9 @@ queue_rules:
     conditions:
       # Conditions to get out of the queue (= merged)
       - check-success=DCO
-      - check-success=validate
+      - check-success="Validate lint"
+      - check-success="Validate test"
+      - check-success="Validate verify"
 
 pull_request_rules:
   - name: Automatic merge on approval
@@ -13,7 +15,9 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "#review-requested=0"
       - check-success=DCO
-      - check-success=validate
+      - check-success="Validate lint"
+      - check-success="Validate test"
+      - check-success="Validate verify"
       - label!=do-not-merge
       - label=ready-to-merge
     actions:


### PR DESCRIPTION
## Description

Have Mergify wait on the correct/actual checks that GHA runs.

## Why is this needed

Without the actual action names, Mergify will block forever waiting on the `validate` action to complete successfully but GHA will never send it.
