### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/settings.yml @detiber @displague @micahhausler
+/.github/CODEOWNERS @detiber @displague @micahhausler

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,24 @@
+# Collaborators: give specific users access to this repository.
+# See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
+collaborators:
+  # Maintainers, should also be added to the .github/CODEOWNERS file as owners of this settings.yml file.
+  - username: detiber
+    permission: maintain
+  - username: displague
+    permission: maintain
+  - username: micahhausler
+    permission: maintain
+  # Approvers
+  - username: tstromberg
+    permission: push
+  # Reviewers
+  - username: mmlb
+    permission: triage
+
+  # Note: `permission` is only valid on organization-owned repositories.
+  # The permission to grant the collaborator. Can be one of:
+  # * `pull` - can pull, but not push to or administer this repository.
+  # * `push` - can pull and push, but not administer this repository.
+  # * `admin` - can pull, push and administer this repository.
+  # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+  # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,3 +1,0 @@
-#OWNERS
-
-Please see [https://github.com/tinkerbell/.github/blob/main/OWNERS.md](https://github.com/tinkerbell/.github/blob/main/OWNERS.md).


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Description

Add CODEOWNERS based on tinkerbell/org#10

## Why is this needed

Allows additional folks to review and approve changes

