### PR TITLE
Update go to 1.17

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Go Version to setup'
     required: true
-    default: "1.16"
+    default: "1.17"
 runs:
   using: "composite"
   steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,13 +107,13 @@ linters-settings:
       - pkg: sigs.k8s.io/controller-runtime
         alias: ctrl
   gosimple:
-    go: "1.16"
+    go: "1.17"
   staticcheck:
-    go: "1.16"
+    go: "1.17"
   stylecheck:
-    go: "1.16"
+    go: "1.17"
   unused:
-    go: "1.16"
+    go: "1.17"
   tagliatelle:
     case:
       # use-field-name: true

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,13 @@
 module github.com/tinkerbell/cluster-api-provider-tinkerbell
 
-go 1.16
+go 1.17
 
 require (
 	github.com/go-logr/logr v0.4.0
 	github.com/google/uuid v1.3.0
 	github.com/onsi/gomega v1.17.0
-	github.com/prometheus/common v0.30.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/tinkerbell/tink v0.0.0-20210910200746-3743d31e0cf0
-	go.uber.org/atomic v1.9.0 // indirect
 	google.golang.org/grpc v1.41.0
 	google.golang.org/protobuf v1.27.1
 	k8s.io/api v0.22.8
@@ -21,4 +19,56 @@ require (
 	sigs.k8s.io/cluster-api v1.0.2
 	sigs.k8s.io/controller-runtime v0.10.3
 	sigs.k8s.io/yaml v1.3.0
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coredns/caddy v1.1.0 // indirect
+	github.com/coredns/corefile-migration v1.0.13 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/gobuffalo/flect v0.2.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.30.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	go.opentelemetry.io/contrib v0.22.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.22.0 // indirect
+	go.opentelemetry.io/otel v1.0.0-RC2 // indirect
+	go.opentelemetry.io/otel/trace v1.0.0-RC2 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
+	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apiextensions-apiserver v0.22.2 // indirect
+	k8s.io/cluster-bootstrap v0.22.2 // indirect
+	k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )

--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -51,6 +51,6 @@ cd "${tmp_dir}"
 go mod init fake/mod
 
 # install the golang module specified as the first argument
-go get -tags tools "${1}@${3}"
+go install -tags tools "${1}@${3}"
 mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
 ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Description

Update to a maintained version of Go


## Why is this needed

We want to be using modern language versions


## How Has This Been Tested?

Passes CI

## How are existing users impacted? What migration steps/scripts do we need?

No impact

