### PR TITLE
Update kustomize version from v3 to v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ $(GOLANGCI_LINT): ## Build golangci-lint from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 
 $(KUSTOMIZE): ## Build kustomize from tools folder.
-	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) sigs.k8s.io/kustomize/kustomize/v3 $(KUSTOMIZE_BIN) $(KUSTOMIZE_VER)
+	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) sigs.k8s.io/kustomize/kustomize/v4 $(KUSTOMIZE_BIN) $(KUSTOMIZE_VER)
 
 $(CONTROLLER_GEN): ## Build controller-gen from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) sigs.k8s.io/controller-tools/cmd/controller-gen $(CONTROLLER_GEN_BIN) $(CONTROLLER_GEN_VER)


### PR DESCRIPTION
Signed-off-by: panktishah26 <shah.pankti2609@gmail.com>

## Description
The command `make release-manifests` is failing because it is unable to install go install `sigs.k8s.io/kustomize/kustomize/v3@v4.5.4: sigs.k8s.io/kustomize/kustomize/v3@v4.5.4`. I have updated Makefile to use kustomize version v4 to resolve this issue.


Fixes: #

## How are existing users impacted? What migration steps/scripts do we need?

No migration need from from the user side.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
