### PR TITLE
Increase CAPT manager resource limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,8 +40,8 @@ spec:
             port: healthz
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 200Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
## Description

This PR increases the CAPT manager resource limits.

## Why is this needed

CAPT has been known to run into OOM situations due to insufficient memory
resource limits in the pod definition.

Fixes: #

## How Has This Been Tested?

Installed CAPT pod in a local kind cluster and checked the pod definition.

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
