### PR TITLE
Use Update instead of Patch to update ownership labels on hardware resources

### DIFF
--- a/controllers/machine.go
+++ b/controllers/machine.go
@@ -264,11 +264,6 @@ func (mrc *machineReconcileContext) ensureTemplate(hardware *tinkv1.Hardware) er
 }
 
 func (mrc *machineReconcileContext) takeHardwareOwnership(hardware *tinkv1.Hardware) error {
-	patchHelper, err := patch.NewHelper(hardware, mrc.client)
-	if err != nil {
-		return fmt.Errorf("initializing patch helper for selected hardware: %w", err)
-	}
-
 	if len(hardware.ObjectMeta.Labels) == 0 {
 		hardware.ObjectMeta.Labels = map[string]string{}
 	}
@@ -279,7 +274,7 @@ func (mrc *machineReconcileContext) takeHardwareOwnership(hardware *tinkv1.Hardw
 	// Add finalizer to hardware as well to make sure we release it before Machine object is removed.
 	controllerutil.AddFinalizer(hardware, infrastructurev1.MachineFinalizer)
 
-	if err := patchHelper.Patch(mrc.ctx, hardware); err != nil {
+	if err := mrc.client.Update(mrc.ctx, hardware); err != nil {
 		return fmt.Errorf("patching Hardware object: %w", err)
 	}
 


### PR DESCRIPTION
This addresses a hardware assignment race among reconciler threads.
The race would cause the same hardware/server to get assigned to
different tinkerbell machines.

By using Update(replace) instead of patch, we ensure that ownership
label udpate on the hardware resource happens atomically. Update
helps ensure that no changes were made to a resource between the
time it was read and the time it gets updated.

Signed-off-by: Pooja Trivedi <tripooja@amazon.com>

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
