### PR TITLE
Fix tink hardware patching:

### DIFF
--- a/controllers/machine.go
+++ b/controllers/machine.go
@@ -158,10 +158,7 @@ func (mrc *machineReconcileContext) Reconcile() error {
 			return nil
 		}
 
-		hw.Spec.Metadata.State = inUse
-		hw.Spec.Metadata.Instance.State = provisioned
-
-		if err := mrc.patchHardware(hw); err != nil {
+		if err := mrc.patchHardwareStates(hw, inUse, provisioned); err != nil {
 			return fmt.Errorf("failed to patch hardware: %w", err)
 		}
 	}
@@ -171,11 +168,15 @@ func (mrc *machineReconcileContext) Reconcile() error {
 	return nil
 }
 
-func (mrc *machineReconcileContext) patchHardware(hw *tinkv1.Hardware) error {
+// patchHardwareStates patches a hardware's metadata and instance states.
+func (mrc *machineReconcileContext) patchHardwareStates(hw *tinkv1.Hardware, mdState, iState string) error {
 	patchHelper, err := patch.NewHelper(hw, mrc.client)
 	if err != nil {
 		return fmt.Errorf("initializing patch helper for selected hardware: %w", err)
 	}
+
+	hw.Spec.Metadata.State = mdState
+	hw.Spec.Metadata.Instance.State = iState
 
 	if err := patchHelper.Patch(mrc.ctx, hw); err != nil {
 		return fmt.Errorf("patching Hardware object: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/go-logr/logr v0.4.0
+	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
@@ -34,7 +35,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The patching of tink hardware was not working. `metadata.State` and `instance.State` were not being set. The use of patch.NewHelper requires specific ordering.

CC @pokearu

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
