### PR TITLE
Allow for templateOverride string field to be mutable

### DIFF
--- a/api/v1beta1/tinkerbellmachinetemplate_webhook.go
+++ b/api/v1beta1/tinkerbellmachinetemplate_webhook.go
@@ -55,7 +55,12 @@ func (m *TinkerbellMachineTemplate) ValidateUpdate(old runtime.Object) error {
 	oldTinkerbellMachineTemplate, _ := old.(*TinkerbellMachineTemplate)
 
 	if !reflect.DeepEqual(m.Spec, oldTinkerbellMachineTemplate.Spec) {
-		return apierrors.NewBadRequest("TinkerbellMachineTemplate.Spec is immutable")
+		newTemplateSpec := m.Spec.Template.Spec
+		oldTemplateSpec := oldTinkerbellMachineTemplate.Spec.Template.Spec
+
+		if !reflect.DeepEqual(newTemplateSpec.HardwareAffinity, oldTemplateSpec.HardwareAffinity) {
+			return apierrors.NewBadRequest("TinkerbellMachineTemplate.Spec.Template.Spec.HardwareAffinity is immutable")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
... in TinkerbellMachineTemplate. HardwareAffinity must be immutable.

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
