### PR TITLE
Maintainership Application

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/.github/settings.yml @detiber @displague @micahhausler
-/.github/CODEOWNERS @detiber @displague @micahhausler
+/.github/settings.yml @displague @micahhausler @chrisdoherty4
+/.github/CODEOWNERS @displague @micahhausler @chrisdoherty4

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,16 +2,16 @@
 # See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
 collaborators:
   # Maintainers, should also be added to the .github/CODEOWNERS file as owners of this settings.yml file.
-  - username: detiber
-    permission: maintain
   - username: displague
     permission: maintain
   - username: micahhausler
     permission: maintain
+  - username: chrisdoherty4
+    permission: maintain
   # Approvers
   - username: tstromberg
     permission: push
-  - username: chrisdoherty4
+  - username: detiber
     permission: push
   # Reviewers
   - username: mmlb


### PR DESCRIPTION
In conjunction with the loss of an existing maintainer I'm applying for maintainership as I try to drive releasing of CAPT. Having developed Rufio it makes sense to also be a maintainer of CAPT so I think there's an element of [fast-tracking](https://github.com/tinkerbell/org/pull/23) at play that's been principally agreed by maintainers already.

Additionally, this PR reduces @detiber to approver as they've stepped back from Tinkerbell. There's no governance around this currently but this feels like an appropriate move even if detiber can't contribute much.