### PR TITLE
Fix CAPT permissions for new Rufio APIs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,7 +16,7 @@ rules:
 - apiGroups:
   - bmc.tinkerbell.org
   resources:
-  - bmcjobs
+  - jobs
   verbs:
   - create
   - get

--- a/controllers/tinkerbellmachine_controller.go
+++ b/controllers/tinkerbellmachine_controller.go
@@ -51,7 +51,7 @@ type TinkerbellMachineReconciler struct {
 // +kubebuilder:rbac:groups=tinkerbell.org,resources=hardware;hardware/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=tinkerbell.org,resources=templates;templates/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=tinkerbell.org,resources=workflows;workflows/status,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=bmc.tinkerbell.org,resources=bmcjobs,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=bmc.tinkerbell.org,resources=jobs,verbs=get;list;watch;create
 
 // Reconcile ensures that all Tinkerbell machines are aligned with a given spec.
 func (tmr *TinkerbellMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
The Rufio API was updated and changed the names of API types. Specifically, the `BMCJob` watched by CAPT is now a `Job`.