### PR TITLE
Fix 0.3 CAPI version mapping

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -1,7 +1,0 @@
-{
-    "name": "infrastructure-tinkerbell",
-    "config": {
-      "componentsFile": "infrastructure-components.yaml",
-      "nextVersion": "v0.1.0"
-    }
-}

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -25,7 +25,7 @@ and `kubeadm` control-plane providers.
 cat >> ~/.cluster-api/clusterctl.yaml <<EOF
 providers:
   - name: "tinkerbell"
-    url: "https://github.com/tinkerbell/cluster-api-provider-tinkerbell/releases/download/v0.1.0/infrastructure-components.yaml"
+    url: "https://github.com/tinkerbell/cluster-api-provider-tinkerbell/releases/latest/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 EOF
 
@@ -33,7 +33,7 @@ EOF
 clusterctl init --infrastructure tinkerbell
 ```
 
-The output of `clusterctl init` is similar to this:
+The output of `clusterctl init` is similar to the following:
 
 ```shell
 Fetching providers

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,6 +5,9 @@
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
-- major: 0
-  minor: 1
-  contract: v1beta1
+  - major: 0
+    minor: 3
+    contract: v1beta1
+  - major: 0
+    minor: 1
+    contract: v1beta1


### PR DESCRIPTION
This change adds a CAPI version mapping to CAPT. The version mapping is metadata used by CAPI when installing the infrastructure provider and it must include the provider version being deployed. This doesn't really fix the problem as we don't intend on cutting a v0.3.1 with the change but it at least creates a record in the history. 

v0.4.0 will be cut in the coming weeks.

Additionally update the quick start with URLs that are usable.