### PR TITLE
Fix release ci step around checkout:

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup-go
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache: true
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Fixes GitHub actions error:
"Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/cluster-api-provider-tinkerbell/cluster-api-provider-tinkerbell/.github/actions/setup-go'. Did you forget to run actions/checkout before running your local action?"

## Why is this needed

Release CI is broken.

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
