### PR TITLE
Update infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
@@ -228,7 +228,7 @@ spec:
                       templateOverride:
                         description: |-
                           TemplateOverride overrides the default Tinkerbell template used by CAPT.
-                          You can learn more about Tinkerbell templates here: https://docs.tinkerbell.org/templates/
+                          You can learn more about Tinkerbell templates here: https://tinkerbell.org/docs/concepts/templates/
                         type: string
                     type: object
                 required:


### PR DESCRIPTION
## Description

Update old references pointing to docs.tinkerbell.org -> https://tinkerbell.org/docs/

## Why is this needed

Old documentation is confusing for new users