### PR TITLE
Updating old documentation links to point to new locations

### DIFF
--- a/api/v1beta1/tinkerbellmachine_types.go
+++ b/api/v1beta1/tinkerbellmachine_types.go
@@ -61,7 +61,7 @@ type TinkerbellMachineSpec struct {
 	ImageLookupOSVersion string `json:"imageLookupOSVersion,omitempty"`
 
 	// TemplateOverride overrides the default Tinkerbell template used by CAPT.
-	// You can learn more about Tinkerbell templates here: https://docs.tinkerbell.org/templates/
+	// You can learn more about Tinkerbell templates here: https://tinkerbell.org/docs/concepts/templates/
 	// +optional
 	TemplateOverride string `json:"templateOverride,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -236,7 +236,7 @@ spec:
               templateOverride:
                 description: |-
                   TemplateOverride overrides the default Tinkerbell template used by CAPT.
-                  You can learn more about Tinkerbell templates here: https://docs.tinkerbell.org/templates/
+                  You can learn more about Tinkerbell templates here: https://tinkerbell.org/docs/concepts/templates/
                 type: string
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
@@ -228,7 +228,7 @@ spec:
                       templateOverride:
                         description: |-
                           TemplateOverride overrides the default Tinkerbell template used by CAPT.
-                          You can learn more about Tinkerbell templates here: https://docs.tinkerbell.org/templates/
+                          You can learn more about Tinkerbell templates here: https://tinkerbell.org/docs/concepts/templates/
                         type: string
                     type: object
                 required:


### PR DESCRIPTION
## Description

Updating old documentation links to point to new locations. docs.tinkerbell.org -> tinkerbell.org/docs/

## Why is this needed

Old documentation is confusing for new users.