### PR TITLE
Use netboot.AllowPXE to determine hardware ready status

### DIFF
--- a/controllers/tinkerbellmachine_controller_test.go
+++ b/controllers/tinkerbellmachine_controller_test.go
@@ -190,6 +190,9 @@ func validHardware(name, uuid, ip string, options ...testOptions) *tinkv1.Hardwa
 							Address: ip,
 						},
 					},
+					Netboot: &tinkv1.Netboot{
+						AllowPXE: ptr.To(true),
+					},
 				},
 			},
 			Metadata: &tinkv1.HardwareMetadata{
@@ -417,7 +420,7 @@ func Test_Machine_reconciliation_with_available_hardware(t *testing.T) {
 		g.Expect(updatedMachine.Status.Addresses).NotTo(BeEmpty(), "Machine status should be updated on every reconciliation")
 	})
 
-	t.Run("in_use_states_are_not_set", func(t *testing.T) {
+	t.Run("allowPXE_is_not_updated", func(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
@@ -428,10 +431,7 @@ func Test_Machine_reconciliation_with_available_hardware(t *testing.T) {
 
 		updatedHardware := &tinkv1.Hardware{}
 		g.Expect(client.Get(ctx, hardwareNamespacedName, updatedHardware)).To(Succeed())
-		if diff := cmp.Diff(updatedHardware.Spec.Metadata.State, ""); diff != "" {
-			t.Errorf(diff)
-		}
-		if diff := cmp.Diff(updatedHardware.Spec.Metadata.Instance.State, ""); diff != "" {
+		if diff := cmp.Diff(updatedHardware.Spec.Interfaces[0].Netboot.AllowPXE, ptr.To(true)); diff != "" {
 			t.Errorf(diff)
 		}
 	})
@@ -554,7 +554,7 @@ func Test_Machine_reconciliation_workflow_complete(t *testing.T) {
 		g.Expect(updatedMachine.Status.Addresses).NotTo(BeEmpty(), "Machine status should be updated on every reconciliation")
 	})
 
-	t.Run("in_use_states_are_set", func(t *testing.T) {
+	t.Run("allowPXE_is_updated", func(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 
@@ -565,10 +565,7 @@ func Test_Machine_reconciliation_workflow_complete(t *testing.T) {
 
 		updatedHardware := &tinkv1.Hardware{}
 		g.Expect(client.Get(ctx, hardwareNamespacedName, updatedHardware)).To(Succeed())
-		if diff := cmp.Diff(updatedHardware.Spec.Metadata.State, "in_use"); diff != "" {
-			t.Errorf(diff)
-		}
-		if diff := cmp.Diff(updatedHardware.Spec.Metadata.Instance.State, "provisioned"); diff != "" {
+		if diff := cmp.Diff(updatedHardware.Spec.Interfaces[0].Netboot.AllowPXE, ptr.To(false)); diff != "" {
 			t.Errorf(diff)
 		}
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinkerbell/cluster-api-provider-tinkerbell
 
-go 1.21
+go 1.21.0
 
 toolchain go1.21.2
 


### PR DESCRIPTION
## Description
This PR changes CAPT to look at `hardware.Spec.Interfaces[].netboot.AllowPXE` to determine if the hardware is ready and gate network booting

## Why is this needed
Gating of network booting in Smee now occurs via `Hardware.Spec.Interfaces[].Netboot.AllowPXE`, so we need to update the logic in CAPT

Fixes: https://github.com/tinkerbell/cluster-api-provider-tinkerbell/issues/363

## How Has This Been Tested?
Tested manually following these steps:
1. Provision a cluster with CAPT
2. Set a machine's firmware to network boot
3. Reboot the machine

and verified that the machine does not go into network boot after the reboot

## Checklist:

I have:
- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
