### PR TITLE
Add error handling for ISO boot mode:

### DIFF
--- a/controller/machine/workflow.go
+++ b/controller/machine/workflow.go
@@ -54,6 +54,9 @@ func (scope *machineReconcileScope) createWorkflow(hw *tinkv1.Hardware) error {
 			TemplateRef: scope.tinkerbellMachine.Name,
 			HardwareRef: hw.Name,
 			HardwareMap: map[string]string{"device_1": hw.Spec.Metadata.Instance.ID},
+			BootOptions: tinkv1.BootOptions{
+				ToggleAllowNetboot: true,
+			},
 		},
 	}
 
@@ -63,11 +66,12 @@ func (scope *machineReconcileScope) createWorkflow(hw *tinkv1.Hardware) error {
 		switch scope.tinkerbellMachine.Spec.BootOptions.BootMode {
 		case v1beta1.BootMode("netboot"):
 			workflow.Spec.BootOptions.BootMode = tinkv1.BootMode("netboot")
-			workflow.Spec.BootOptions.ToggleAllowNetboot = true
 		case v1beta1.BootMode("iso"):
+			if scope.tinkerbellMachine.Spec.BootOptions.ISOURL == "" {
+				return fmt.Errorf("iso boot mode requires an isoURL")
+			}
 			workflow.Spec.BootOptions.BootMode = tinkv1.BootMode("iso")
 			workflow.Spec.BootOptions.ISOURL = scope.tinkerbellMachine.Spec.BootOptions.ISOURL
-			workflow.Spec.BootOptions.ToggleAllowNetboot = true
 		}
 	}
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Error out when isoURL is empty and boot mode is iso. Also, always enable ToggleAllowNetboot.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
