### PR TITLE
Allow TinkerbellMachine to be removed when no Hardware exists:

### DIFF
--- a/controller/machine/hardware.go
+++ b/controller/machine/hardware.go
@@ -279,18 +279,6 @@ func (scope *machineReconcileScope) releaseHardware(hw *tinkv1.Hardware) error {
 	delete(hw.ObjectMeta.Labels, HardwareOwnerNameLabel)
 	delete(hw.ObjectMeta.Labels, HardwareOwnerNamespaceLabel)
 	delete(hw.ObjectMeta.Annotations, HardwareProvisionedAnnotation)
-	/*
-		// setting the AllowPXE=true indicates to Smee that this hardware should be allowed
-		// to netboot. FYI, this is not authoritative.
-		// Other hardware values can be set to prohibit netbooting of a machine.
-		// See this Boots function for the logic around this:
-		// https://github.com/tinkerbell/smee/blob/main/internal/ipxe/script/ipxe.go#L112
-		for _, ifc := range hw.Spec.Interfaces {
-			if ifc.Netboot != nil {
-				ifc.Netboot.AllowPXE = ptr.To(true)
-			}
-		}
-	*/
 
 	controllerutil.RemoveFinalizer(hw, infrastructurev1.MachineFinalizer)
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
When a Hardware object corresponding to a tinkerbellmachine object no longer exists, allow the tinkerbellmachine object to be removed and clean up associated template and workflow. This means BMC operations to power the machine off and modify the Hardware object will all be skipped.

While the tinkerbellmachine object can be deleted if the finalizer is removed manually this improves the user experience.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #368

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
