### PR TITLE
Handle ISO url properly:

### DIFF
--- a/api/v1beta1/tinkerbellmachine_types.go
+++ b/api/v1beta1/tinkerbellmachine_types.go
@@ -88,11 +88,13 @@ type BootOptions struct {
 	// When this field is set, the controller will create a job.bmc.tinkerbell.org object
 	// for getting the associated hardware into a CDROM booting state.
 	// A HardwareRef that contains a spec.BmcRef must be provided.
+	//
 	// The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
 	// The name of the ISO file must have the .iso extension, but the name can be anything.
-	// The $IP and $Port should generally point to the IP and Port of the Smee server as this is where
-	// the ISO patching endpoint lives.
-	// The ":macAddress" is a placeholder for the MAC address of the hardware and should be provided exactly as is: ":macAddress".
+	// The $IP and $Port should generally point to the IP and Port of the Smee server
+	// as this is where the ISO patching endpoint lives.
+	// The ":macAddress" is a placeholder for the MAC address of the hardware and
+	// should be provided exactly as is: ":macAddress".
 	// +optional
 	// +kubebuilder:validation:Format=url
 	ISOURL string `json:"isoURL,omitempty"`

--- a/api/v1beta1/tinkerbellmachine_types.go
+++ b/api/v1beta1/tinkerbellmachine_types.go
@@ -88,11 +88,17 @@ type BootOptions struct {
 	// When this field is set, the controller will create a job.bmc.tinkerbell.org object
 	// for getting the associated hardware into a CDROM booting state.
 	// A HardwareRef that contains a spec.BmcRef must be provided.
+	// The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
+	// The name of the ISO file must have the .iso extension, but the name can be anything.
+	// The $IP and $Port should generally point to the IP and Port of the Smee server as this is where
+	// the ISO patching endpoint lives.
+	// The ":macAddress" is a placeholder for the MAC address of the hardware and should be provided exactly as is: ":macAddress".
 	// +optional
 	// +kubebuilder:validation:Format=url
 	ISOURL string `json:"isoURL,omitempty"`
 
 	// BootMode is the type of booting that will be done.
+	// Must be one of "none", "netboot", or "iso".
 	// +optional
 	// +kubebuilder:validation:Enum=none;netboot;iso
 	BootMode BootMode `json:"bootMode,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -66,7 +66,9 @@ spec:
                 description: BootOptions are options that control the booting of Hardware.
                 properties:
                   bootMode:
-                    description: BootMode is the type of booting that will be done.
+                    description: |-
+                      BootMode is the type of booting that will be done.
+                      Must be one of "none", "netboot", or "iso".
                     enum:
                     - none
                     - netboot
@@ -78,6 +80,11 @@ spec:
                       When this field is set, the controller will create a job.bmc.tinkerbell.org object
                       for getting the associated hardware into a CDROM booting state.
                       A HardwareRef that contains a spec.BmcRef must be provided.
+                      The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
+                      The name of the ISO file must have the .iso extension, but the name can be anything.
+                      The $IP and $Port should generally point to the IP and Port of the Smee server as this is where
+                      the ISO patching endpoint lives.
+                      The ":macAddress" is a placeholder for the MAC address of the hardware and should be provided exactly as is: ":macAddress".
                     format: url
                     type: string
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -80,11 +80,13 @@ spec:
                       When this field is set, the controller will create a job.bmc.tinkerbell.org object
                       for getting the associated hardware into a CDROM booting state.
                       A HardwareRef that contains a spec.BmcRef must be provided.
+
                       The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
                       The name of the ISO file must have the .iso extension, but the name can be anything.
-                      The $IP and $Port should generally point to the IP and Port of the Smee server as this is where
-                      the ISO patching endpoint lives.
-                      The ":macAddress" is a placeholder for the MAC address of the hardware and should be provided exactly as is: ":macAddress".
+                      The $IP and $Port should generally point to the IP and Port of the Smee server
+                      as this is where the ISO patching endpoint lives.
+                      The ":macAddress" is a placeholder for the MAC address of the hardware and
+                      should be provided exactly as is: ":macAddress".
                     format: url
                     type: string
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
@@ -70,11 +70,13 @@ spec:
                               When this field is set, the controller will create a job.bmc.tinkerbell.org object
                               for getting the associated hardware into a CDROM booting state.
                               A HardwareRef that contains a spec.BmcRef must be provided.
+
                               The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
                               The name of the ISO file must have the .iso extension, but the name can be anything.
-                              The $IP and $Port should generally point to the IP and Port of the Smee server as this is where
-                              the ISO patching endpoint lives.
-                              The ":macAddress" is a placeholder for the MAC address of the hardware and should be provided exactly as is: ":macAddress".
+                              The $IP and $Port should generally point to the IP and Port of the Smee server
+                              as this is where the ISO patching endpoint lives.
+                              The ":macAddress" is a placeholder for the MAC address of the hardware and
+                              should be provided exactly as is: ":macAddress".
                             format: url
                             type: string
                         type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
@@ -56,8 +56,9 @@ spec:
                           of Hardware.
                         properties:
                           bootMode:
-                            description: BootMode is the type of booting that will
-                              be done.
+                            description: |-
+                              BootMode is the type of booting that will be done.
+                              Must be one of "none", "netboot", or "iso".
                             enum:
                             - none
                             - netboot
@@ -69,6 +70,11 @@ spec:
                               When this field is set, the controller will create a job.bmc.tinkerbell.org object
                               for getting the associated hardware into a CDROM booting state.
                               A HardwareRef that contains a spec.BmcRef must be provided.
+                              The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
+                              The name of the ISO file must have the .iso extension, but the name can be anything.
+                              The $IP and $Port should generally point to the IP and Port of the Smee server as this is where
+                              the ISO patching endpoint lives.
+                              The ":macAddress" is a placeholder for the MAC address of the hardware and should be provided exactly as is: ":macAddress".
                             format: url
                             type: string
                         type: object

--- a/controller/machine/workflow.go
+++ b/controller/machine/workflow.go
@@ -77,13 +77,14 @@ func (scope *machineReconcileScope) createWorkflow(hw *tinkv1.Hardware) error {
 				return errISOBootURLRequired
 			}
 
-			workflow.Spec.BootOptions.BootMode = tinkv1.BootMode("iso")
 			u, err := url.Parse(scope.tinkerbellMachine.Spec.BootOptions.ISOURL)
 			if err != nil {
 				return fmt.Errorf("boot option isoURL is not parse-able: %w", err)
 			}
+
 			u.Path = strings.Replace(u.Path, ":macAddress", strings.Replace(hw.Spec.Metadata.Instance.ID, ":", "-", 5), 1)
 			workflow.Spec.BootOptions.ISOURL = u.String()
+			workflow.Spec.BootOptions.BootMode = tinkv1.BootMode("iso")
 		}
 	}
 

--- a/controller/machine/workflow.go
+++ b/controller/machine/workflow.go
@@ -3,6 +3,8 @@ package machine
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
 
@@ -76,7 +78,12 @@ func (scope *machineReconcileScope) createWorkflow(hw *tinkv1.Hardware) error {
 			}
 
 			workflow.Spec.BootOptions.BootMode = tinkv1.BootMode("iso")
-			workflow.Spec.BootOptions.ISOURL = scope.tinkerbellMachine.Spec.BootOptions.ISOURL
+			u, err := url.Parse(scope.tinkerbellMachine.Spec.BootOptions.ISOURL)
+			if err != nil {
+				return fmt.Errorf("boot option isoURL is not parse-able: %w", err)
+			}
+			u.Path = strings.Replace(u.Path, ":macAddress", strings.Replace(hw.Spec.Metadata.Instance.ID, ":", "-", 5), 1)
+			workflow.Spec.BootOptions.ISOURL = u.String()
 		}
 	}
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Workflows and Smee require the ISO url mac address in dash notation. CAPT needs to provide a placeholder for this value so that it can be added by the reconciler.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
