### PR TITLE
Fix tinkerbell machine reconciliation bug

### DIFF
--- a/controller/machine/scope.go
+++ b/controller/machine/scope.go
@@ -130,6 +130,8 @@ func (scope *machineReconcileScope) reconcile(hw *tinkv1.Hardware) error {
 	if v, found := hw.ObjectMeta.GetAnnotations()[HardwareProvisionedAnnotation]; found && v == "true" {
 		scope.log.Info("Marking TinkerbellMachine as Ready")
 		scope.tinkerbellMachine.Status.Ready = true
+
+		return nil
 	}
 
 	wf, err := scope.ensureTemplateAndWorkflow(hw)


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This change is going to make the reconciler return early when we find that the hardware owned by the tinkerbellmachine is already provisioned.

## Why is this needed
When the hardware machine is provisioned there's nothing to reconcile, we missed returning early which caused the  machine reconciler to recreate the workflows and this lead to machine getting provisioned again whenever the CAPT and TNK objects moved from one cluster to another. 

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested a local build to ensure the machine wasn't reprovisioned after moving from one cluster to another. 
## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
