### PR TITLE
rm caBundle

### DIFF
--- a/config/crd/patches/webhook_in_tinkerbellclusters.yaml
+++ b/config/crd/patches/webhook_in_tinkerbellclusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_tinkerbellmachines.yaml
+++ b/config/crd/patches/webhook_in_tinkerbellmachines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_tinkerbellmachinetemplates.yaml
+++ b/config/crd/patches/webhook_in_tinkerbellmachinetemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
## Description

Drop caBundle from CRDs to support Kubernetes 1.31
https://github.com/kubernetes-sigs/cluster-api/pull/10972

## Why is this needed

Allow provider to work with k8s 1.31

Fixes: #
```
message: 'action failed after 10 attempts: failed to patch provider object: CustomResourceDefinition.apiextensions.k8s.io
      "tinkerbellclusters.infrastructure.cluster.x-k8s.io" is invalid: spec.conversion.webhookClientConfig.caBundle:
      Invalid value: []byte{0xa}: unable to load root certificates: unable to parse
      bytes as PEM block'
```

Tests:

Deployed on local k8s 1.31, with tilt.