### PR TITLE
Default hardware MAC in iso mount workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GOVER=1.23
-FROM golang:${GOVER} as builder
+FROM golang:${GOVER} AS builder
 
 WORKDIR /workspace
 

--- a/api/v1beta1/tinkerbellmachine_types.go
+++ b/api/v1beta1/tinkerbellmachine_types.go
@@ -85,16 +85,17 @@ type TinkerbellMachineSpec struct {
 // BootOptions are options that control the booting of Hardware.
 type BootOptions struct {
 	// ISOURL is the URL of the ISO that will be one-time booted.
-	// When this field is set, the controller will create a job.bmc.tinkerbell.org object
-	// for getting the associated hardware into a CDROM booting state.
 	// A HardwareRef that contains a spec.BmcRef must be provided.
 	//
-	// The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
+	// The format of the ISOURL must be http://$IP:$Port/iso/hook.iso
 	// The name of the ISO file must have the .iso extension, but the name can be anything.
 	// The $IP and $Port should generally point to the IP and Port of the Smee server
 	// as this is where the ISO patching endpoint lives.
-	// The ":macAddress" is a placeholder for the MAC address of the hardware and
-	// should be provided exactly as is: ":macAddress".
+	// The controller will append the MAC address of the hardware in the ISO URL
+	// right before the iso file name in the URL.
+	// MAC address is then used to retrieve hardware specific information such as
+	// IPAM info, custom kernel cmd line args and populate the worker ID for the tink worker/agent.
+	// For ex. the above format would be replaced to http://$IP:$Port/iso/<macAddress>/hook.iso
 	// +optional
 	// +kubebuilder:validation:Format=url
 	ISOURL string `json:"isoURL,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -77,16 +77,17 @@ spec:
                   isoURL:
                     description: |-
                       ISOURL is the URL of the ISO that will be one-time booted.
-                      When this field is set, the controller will create a job.bmc.tinkerbell.org object
-                      for getting the associated hardware into a CDROM booting state.
                       A HardwareRef that contains a spec.BmcRef must be provided.
 
-                      The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
+                      The format of the ISOURL must be http://$IP:$Port/iso/hook.iso
                       The name of the ISO file must have the .iso extension, but the name can be anything.
                       The $IP and $Port should generally point to the IP and Port of the Smee server
                       as this is where the ISO patching endpoint lives.
-                      The ":macAddress" is a placeholder for the MAC address of the hardware and
-                      should be provided exactly as is: ":macAddress".
+                      The controller will append the MAC address of the hardware in the ISO URL
+                      right before the iso file name in the URL.
+                      MAC address is then used to retrieve hardware specific information such as
+                      IPAM info, custom kernel cmd line args and populate the worker ID for the tink worker/agent.
+                      For ex. the above format would be replaced to http://$IP:$Port/iso/<macAddress>/hook.iso
                     format: url
                     type: string
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachinetemplates.yaml
@@ -67,16 +67,17 @@ spec:
                           isoURL:
                             description: |-
                               ISOURL is the URL of the ISO that will be one-time booted.
-                              When this field is set, the controller will create a job.bmc.tinkerbell.org object
-                              for getting the associated hardware into a CDROM booting state.
                               A HardwareRef that contains a spec.BmcRef must be provided.
 
-                              The format of the ISOURL must be http://$IP:$Port/iso/:macAddress/hook.iso
+                              The format of the ISOURL must be http://$IP:$Port/iso/hook.iso
                               The name of the ISO file must have the .iso extension, but the name can be anything.
                               The $IP and $Port should generally point to the IP and Port of the Smee server
                               as this is where the ISO patching endpoint lives.
-                              The ":macAddress" is a placeholder for the MAC address of the hardware and
-                              should be provided exactly as is: ":macAddress".
+                              The controller will append the MAC address of the hardware in the ISO URL
+                              right before the iso file name in the URL.
+                              MAC address is then used to retrieve hardware specific information such as
+                              IPAM info, custom kernel cmd line args and populate the worker ID for the tink worker/agent.
+                              For ex. the above format would be replaced to http://$IP:$Port/iso/<macAddress>/hook.iso
                             format: url
                             type: string
                         type: object

--- a/controller/machine/workflow.go
+++ b/controller/machine/workflow.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
@@ -82,7 +83,9 @@ func (scope *machineReconcileScope) createWorkflow(hw *tinkv1.Hardware) error {
 				return fmt.Errorf("boot option isoURL is not parse-able: %w", err)
 			}
 
-			u.Path = strings.Replace(u.Path, ":macAddress", strings.Replace(hw.Spec.Metadata.Instance.ID, ":", "-", 5), 1)
+			urlPath, file := path.Split(u.Path)
+			u.Path = path.Join(urlPath, strings.Replace(hw.Spec.Metadata.Instance.ID, ":", "-", 5), file)
+
 			workflow.Spec.BootOptions.ISOURL = u.String()
 			workflow.Spec.BootOptions.BootMode = tinkv1.BootMode("iso")
 		}


### PR DESCRIPTION
## Description

For ISO bootmode, the controller required a placeHolder ":macAddress" to be present in the ISOURL which would then later be replaced to the MAC address of the actual hardware during the workflow creation time. Default the logic to append hardware MAC before the ISO file name by default without any placeholder, as we are doing it anyways right now and this slightly alleviates the user experience.

## Why is this needed
Improves UX

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built a custom CAPT image, and verified that the macAddress was populated in the workflow object. 

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
