### PR TITLE
Wait for poweroff job properly on machine delete:

### DIFF
--- a/controller/machine/bmc.go
+++ b/controller/machine/bmc.go
@@ -48,7 +48,7 @@ func (scope *machineReconcileScope) createPowerOffJob(hw *tinkv1.Hardware) error
 		"Name", bmcJob.Name,
 		"Namespace", bmcJob.Namespace)
 
-	return nil
+	return fmt.Errorf("requeue to wait for job.bmc completion: %s/%s", bmcJob.Namespace, bmcJob.Name)
 }
 
 // getJob fetches the Job by name.
@@ -90,5 +90,5 @@ func (scope *machineReconcileScope) ensureBMCJobCompletionForDelete(hardware *ti
 		return fmt.Errorf("bmc job %s/%s failed", bmcJob.Namespace, bmcJob.Name) //nolint:goerr113
 	}
 
-	return nil
+	return fmt.Errorf("requeue, bmc job %s/%s is not completed", bmcJob.Namespace, bmcJob.Name) //nolint:goerr113
 }

--- a/controller/machine/bmc.go
+++ b/controller/machine/bmc.go
@@ -48,7 +48,7 @@ func (scope *machineReconcileScope) createPowerOffJob(hw *tinkv1.Hardware) error
 		"Name", bmcJob.Name,
 		"Namespace", bmcJob.Namespace)
 
-	return fmt.Errorf("requeue to wait for job.bmc completion: %s/%s", bmcJob.Namespace, bmcJob.Name)
+	return fmt.Errorf("requeue to wait for job.bmc completion: %s/%s", bmcJob.Namespace, bmcJob.Name) //nolint:goerr113
 }
 
 // getJob fetches the Job by name.


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

poweroff job.bmc jobs were being deleted before they were completed successfully. This cause requeues so that the job.bmc job will complete successfully before moving on in DeleteMachineWithDependencies.


## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
