### PR TITLE
Update binary and image build process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,11 @@ jobs:
   build-binaries:
     name: Build the CAPT binary
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+          - arch: arm64
     steps:
       - uses: actions/checkout@v5
 
@@ -66,12 +71,12 @@ jobs:
           cache: true
 
       - name: Build
-        run: make build
+        run: ARCH=${{ matrix.arch }} make build
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
-          name: capt-binaries
+          name: capt-${{ matrix.arch }}-binary
           path: |
             dist/*
           if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    needs: build-binaries, codespell, validate
+    # Only build and push container images on pushes to tags
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/'))
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,11 +57,6 @@ jobs:
   build-binaries:
     name: Build binary
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - arch: amd64
-          - arch: arm64
     steps:
       - uses: actions/checkout@v5
 
@@ -71,18 +66,24 @@ jobs:
           cache: true
 
       - name: Build
-        run: ARCH=${{ matrix.arch }} make build
+        run: make build
 
-      - name: Upload
-        uses: actions/upload-artifact@v4
+  build-container-images:
+    name: Build container images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
         with:
-          name: capt-${{ matrix.arch }}-binary
-          path: |
-            dist/*
-          if-no-files-found: error
+          go-version: "${{ env.GO_VERSION }}"
+          cache: true
+
+      - name: Build
+        run: make build-image
   
   build-and-push-container-images:
-    name: Build and push manager image
+    name: Build and push container images
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
       packages: write
     needs:
     - build-binaries
+    - build-container-images
     - codespell
     - validate
     # Only build and push container images on pushes to tags

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,10 @@ jobs:
     permissions:
       contents: read
       packages: write
-    needs: build-binaries, codespell, validate
+    needs:
+    - build-binaries
+    - codespell
+    - validate
     # Only build and push container images on pushes to tags
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/'))
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
           ignore_words_list: ro,NotIn
   
   build-binaries:
-    name: Build the CAPT binary
+    name: Build binary
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -73,7 +73,7 @@ jobs:
       - name: Build
         run: ARCH=${{ matrix.arch }} make build
 
-      - name: Upload binaries
+      - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: capt-${{ matrix.arch }}-binary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           check_filenames: true
           check_hidden: true
-          skip: "./.git,./go.mod,./go.sum"
+          skip: "./.git,./go.mod,./go.sum,.goreleaser.yaml"
           ignore_words_list: ro,NotIn
   
   build-binaries:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   CGO_ENABLED: 0
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25.1'
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
@@ -53,8 +53,30 @@ jobs:
           check_hidden: true
           skip: "./.git,./go.mod,./go.sum"
           ignore_words_list: ro,NotIn
+  
+  build-binaries:
+    name: Build the CAPT binary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
 
-  build-and-push-image:
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache: true
+
+      - name: Build
+        run: make build
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: capt-binaries
+          path: |
+            dist/*
+          if-no-files-found: error
+  
+  build-and-push-container-images:
     name: Build and push manager image
     runs-on: ubuntu-latest
     permissions:
@@ -73,27 +95,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
-            type=sha
-            type=raw,value=latest
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build and push Docker image
-      id: build-and-push
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+    - name: Build and push container images
+      if: github.event_name != 'pull_request'
+      run: make image-build

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ dist
 
 # development / test / lints
 bin/
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,43 +12,37 @@ before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
 
 builds:
-  - env:
+  - id: capt
+    binary: capt
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
+    ldflags:
+      - -s -w
     goarch:
       - amd64
       - arm64
 
 archives:
-  - formats: [tar.gz]
-    # this name template makes the OS and Arch compatible with the results of `uname`.
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        formats: [zip]
+  - formats:
+    - binary
 
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-
-release:
-  footer: >-
-
-    ---
-
-    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
+kos:
+  - id: capt
+    platforms:
+    - linux/amd64
+    - linux/arm64
+    tags:
+    - latest
+    - '{{.Tag}}'
+    bare: true
+    env:
+    - CGO_ENABLED=0
+    ldflags:
+    - -s -w
+    repositories:
+    - ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
+    local_domain: ghcr.io/tinkerbell/cluster-api-provider-tinkerbell

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,48 +1,46 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
-
-# The lines below are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/need to use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj
-
 version: 2
+
+env:
+  - REGISTRY={{ if index .Env "REGISTRY"  }}{{ .Env.REGISTRY }}{{ else }}ghcr.io{{ end }}
+  - IMAGE_NAME={{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else }}tinkerbell/cluster-api-provider-tinkerbell{{ end }}
+  - BINARY=capt
 
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
 
 builds:
-  - id: capt
-    binary: capt
+  - id: build
+    binary: "{{ .Env.BINARY }}"
     env:
-      - CGO_ENABLED=0
+    - CGO_ENABLED=0
     goos:
-      - linux
+    - linux
     ldflags:
-      - -s -w
+    - -s -w
     goarch:
-      - amd64
-      - arm64
+    - amd64
+    - arm64
+
+checksum:
+  name_template: 'checksums.txt'
 
 archives:
   - formats:
     - binary
 
-kos:
-  - id: capt
-    platforms:
-    - linux/amd64
-    - linux/arm64
+release:
+  disable: true
+
+dockers_v2:
+  - images:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}"
     tags:
-    - latest
-    - '{{.Tag}}'
-    bare: true
-    env:
-    - CGO_ENABLED=0
-    ldflags:
-    - -s -w
-    repositories:
-    - ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
-    local_domain: ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
+      - "v{{ .Version }}"
+      - "latest"
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.name": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "v{{.Version}}"
+      "org.opencontainers.image.source": "{{.GitURL}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,54 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,34 +13,36 @@
 # limitations under the License.
 
 # Build the manager binary
-ARG GOVER=1.24
-FROM golang:${GOVER} AS builder
-
-WORKDIR /workspace
-
-# Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
-ARG goproxy=https://proxy.golang.org
-ENV GOPROXY=$goproxy
-
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the sources
-COPY ./ ./
-
-# Build
-ARG ARCH
-ARG LDFLAGS
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags="${LDFLAGS}" -o manager .
+#ARG GOVER=1.24
+#FROM golang:${GOVER} AS builder
+#
+#WORKDIR /workspace
+#
+## Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
+#ARG goproxy=https://proxy.golang.org
+#ENV GOPROXY=$goproxy
+#
+## Copy the Go Modules manifests
+#COPY go.mod go.mod
+#COPY go.sum go.sum
+## cache deps before building and copying source so that we don't need to re-download as much
+## and so that source changes don't invalidate our downloaded layer
+#RUN go mod download
+#
+## Copy the sources
+#COPY ./ ./
+#
+## Build
+#ARG ARCH
+#ARG LDFLAGS
+#RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags="${LDFLAGS}" -o manager .
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
 WORKDIR /
-COPY --from=builder /workspace/manager .
+#COPY --from=builder /workspace/manager .
+COPY dist/cluster-api-provider-tinkerbell_linux_${TARGETARCH}_v1/capt /capt
 USER nonroot:nonroot
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/capt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,37 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build the manager binary
-#ARG GOVER=1.24
-#FROM golang:${GOVER} AS builder
-#
-#WORKDIR /workspace
-#
-## Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
-#ARG goproxy=https://proxy.golang.org
-#ENV GOPROXY=$goproxy
-#
-## Copy the Go Modules manifests
-#COPY go.mod go.mod
-#COPY go.sum go.sum
-## cache deps before building and copying source so that we don't need to re-download as much
-## and so that source changes don't invalidate our downloaded layer
-#RUN go mod download
-#
-## Copy the sources
-#COPY ./ ./
-#
-## Build
-#ARG ARCH
-#ARG LDFLAGS
-#RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags="${LDFLAGS}" -o manager .
-
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
+# Use make 
 FROM gcr.io/distroless/static:nonroot
-ARG TARGETARCH
-WORKDIR /
-#COPY --from=builder /workspace/manager .
-COPY dist/cluster-api-provider-tinkerbell_linux_${TARGETARCH}_v1/capt /capt
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/capt /capt
 USER nonroot:nonroot
 ENTRYPOINT ["/capt"]

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ generate-manifests: tools ## Generate manifests e.g. CRD, RBAC etc.
 
 .PHONY: build
 build: generate ## Build the CAPT binary
-	${GORELEASER} release --snapshot --clean --skip ko
+	GOARCH=${ARCH} ${GORELEASER} build --snapshot --clean --single-target
 
 ## --------------------------------------
 ## Container image build

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,12 @@ KUSTOMIZE_VER := v5.7.1
 KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER)
 
+GORELEASER_VER := v2.11.2
+GORELEASER_BIN := goreleaser
+GORELEASER := $(TOOLS_BIN_DIR)/$(GORELEASER_BIN)-$(GORELEASER_VER)
+
 .PHONY: tools
-tools: $(KUSTOMIZE) $(GOLANGCI_LINT) ## Install build tools
+tools: $(KUSTOMIZE) $(GOLANGCI_LINT) $(GORELEASER) ## Install build tools
 
 TIMEOUT := $(shell command -v timeout || command -v gtimeout)
 
@@ -123,6 +127,11 @@ $(KUSTOMIZE): ## Install kustomize
 	mkdir -p $(TOOLS_BIN_DIR)
 	GOBIN=$(TOOLS_BIN_DIR) go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VER}
 	@mv $(TOOLS_BIN_DIR)/kustomize $(KUSTOMIZE)
+
+$(GORELEASER): ## Install goreleaser
+	mkdir -p $(TOOLS_BIN_DIR)
+	GOBIN=$(TOOLS_BIN_DIR) go install github.com/goreleaser/goreleaser/v2@${GORELEASER_VER}
+	@mv $(TOOLS_BIN_DIR)/goreleaser $(GORELEASER)
 
 ## --------------------------------------
 ## Linting

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,8 @@ GORELEASER_VER := v2.12.2
 GORELEASER_BIN := goreleaser
 GORELEASER := $(TOOLS_BIN_DIR)/$(GORELEASER_BIN)-$(GORELEASER_VER)
 
-KO_VER := v0.18.0
-KO_BIN := ko
-KO := $(TOOLS_BIN_DIR)/$(KO_BIN)-$(KO_VER)
-
 .PHONY: tools
-tools: $(KUSTOMIZE) $(GOLANGCI_LINT) $(GORELEASER) $(KO) ## Install build tools
+tools: $(KUSTOMIZE) $(GOLANGCI_LINT) $(GORELEASER) ## Install build tools
 
 TIMEOUT := $(shell command -v timeout || command -v gtimeout)
 
@@ -136,11 +132,6 @@ $(GORELEASER): ## Install goreleaser
 	mkdir -p $(TOOLS_BIN_DIR)
 	GOBIN=$(TOOLS_BIN_DIR) go install github.com/goreleaser/goreleaser/v2@${GORELEASER_VER}
 	@mv $(TOOLS_BIN_DIR)/goreleaser $(GORELEASER)
-
-$(KO): ## Install ko
-	mkdir -p $(TOOLS_BIN_DIR)
-	GOBIN=$(TOOLS_BIN_DIR) go install github.com/google/ko@${KO_VER}
-	@mv $(TOOLS_BIN_DIR)/ko $(KO)
 
 ## --------------------------------------
 ## Linting
@@ -219,7 +210,7 @@ generate-manifests: tools ## Generate manifests e.g. CRD, RBAC etc.
 ## --------------------------------------
 
 .PHONY: build
-build: generate ## Build the CAPT binary
+build: generate $(GORELEASER) ## Build the CAPT binary
 	GOARCH=${ARCH} ${GORELEASER} build --snapshot --clean
 
 ## --------------------------------------
@@ -227,13 +218,13 @@ build: generate ## Build the CAPT binary
 ## --------------------------------------
 
 .PHONY: build-image
-build-image: ## Build the container image
+build-image: $(GORELEASER) ## Build the container image
 	${GORELEASER} release --snapshot --clean --verbose
 #	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
 #	$(MAKE) set-manifest-pull-policy
 
 .PHONY: image-build-push
-image-build-push: ## Build and push the container image
+image-build-push: $(GORELEASER) ## Build and push the container image
 	${GORELEASER} release --clean --verbose --skip=validate
 
 ## --------------------------------------


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Binary and container image builds are only run on a merge into main. We should be testing this on all PRs. Also, the binary and image builds on main take almost 20mins to run. This PR is to speed up binary and image builds and to have them run on all PRs.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
