### PR TITLE
Fix goreleaser issue:

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,12 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
           cache: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push image
         run: make image-build-push
         env:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
During the goreleaser release process in CI getting this error: `ERROR: failed to build: Attestation is not supported for the docker driver.` The hope is that setting up docker buildx explicitly will get a version that will work properly.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
