### PR TITLE
Build and push container images on main:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,3 +67,39 @@ jobs:
 
       - name: Build
         run: make build-image
+
+  build-push-image:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs:
+      - validate
+      - codespell
+      - build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        run: make build-image-push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_RELEASE: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        run: make image-build-push
+        run: make build-image-push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,7 @@ env:
   - REGISTRY={{ if index .Env "REGISTRY"  }}{{ .Env.REGISTRY }}{{ else }}ghcr.io{{ end }}
   - IMAGE_NAME={{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else }}tinkerbell/cluster-api-provider-tinkerbell{{ end }}
   - BINARY=capt
+  - IS_RELEASE={{ if index .Env "IS_RELEASE" }}{{ .Env.IS_RELEASE }}{{ else }}true{{ end }}
 
 before:
   hooks:
@@ -36,8 +37,9 @@ dockers_v2:
   - images:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}"
     tags:
-      - "v{{ .Version }}"
-      - "{{ if not .IsNightly }}latest{{ end }}"
+      - '{{ if eq .Env.IS_RELEASE "true" }}v{{ .Version }}{{ end }}'
+      - '{{ if not .IsNightly }}latest{{ end }}'
+      - '{{ if eq .Branch "main" }}sha-{{ .ShortCommit }}{{ end }}'
     labels:
       "org.opencontainers.image.created": "{{.Date}}"
       "org.opencontainers.image.name": "{{.ProjectName}}"

--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,8 @@ build: generate $(GORELEASER) ## Build the CAPT binary
 build-image: $(GORELEASER) ## Build the container image
 	${GORELEASER} release --snapshot --clean --verbose
 
-.PHONY: image-build-push
-image-build-push: $(GORELEASER) ## Build and push the container image
+.PHONY: build-image-push
+build-image-push: $(GORELEASER) ## Build and push the container image
 	${GORELEASER} release --clean --verbose
 
 ## --------------------------------------


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
We were building and pushing images from main before moving to goreleaser. This get this functionality back.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
