### PR TITLE
Allow building and pushing from goreleaser on main:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,3 +103,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_RELEASE: false
+          GORELEASER_EXTRA_FLAGS: "--skip=validate"

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ build-image: $(GORELEASER) ## Build the container image
 
 .PHONY: build-image-push
 build-image-push: $(GORELEASER) ## Build and push the container image
-	${GORELEASER} release --clean --verbose
+	${GORELEASER} release --clean --verbose ${GORELEASER_EXTRA_FLAGS}
 
 ## --------------------------------------
 ## Manifest Image Update


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This gets around the error, "git doesn't contain any tags" and allows builds from main without a new tag to push `sha-<git short hash>` and `latest` tags on container image builds.
Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
