### PR TITLE
Use paused.EnsurePausedCondition for v1beta2 contract compliance:

### DIFF
--- a/api/v1beta1/tinkerbellcluster_types.go
+++ b/api/v1beta1/tinkerbellcluster_types.go
@@ -108,7 +108,7 @@ type TinkerbellClusterStatus struct {
 
 	// Conditions defines current service state of the TinkerbellCluster.
 	// +optional
-	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // TinkerbellClusterInitializationStatus provides observations of the TinkerbellCluster initialization process.
@@ -136,12 +136,12 @@ type TinkerbellCluster struct {
 }
 
 // GetConditions returns the conditions for the TinkerbellCluster.
-func (c *TinkerbellCluster) GetConditions() clusterv1.Conditions {
+func (c *TinkerbellCluster) GetConditions() []metav1.Condition {
 	return c.Status.Conditions
 }
 
 // SetConditions sets the conditions on the TinkerbellCluster.
-func (c *TinkerbellCluster) SetConditions(conditions clusterv1.Conditions) {
+func (c *TinkerbellCluster) SetConditions(conditions []metav1.Condition) {
 	c.Status.Conditions = conditions
 }
 

--- a/api/v1beta1/tinkerbellmachine_types.go
+++ b/api/v1beta1/tinkerbellmachine_types.go
@@ -20,7 +20,6 @@ import (
 	tinkv1 "github.com/tinkerbell/tinkerbell/api/v1alpha1/tinkerbell"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
 const (
@@ -175,11 +174,8 @@ type TinkerbellMachineStatus struct {
 	TargetNamespace string `json:"targetNamespace,omitempty"`
 
 	// Conditions defines current service state of the TinkerbellMachine.
-	// Required to satisfy the Cluster API conditions.Getter/conditions.Setter
-	// interface contract. The CAPI framework may call GetConditions/SetConditions
-	// via interface assertion.
 	// +optional
-	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Any transient errors that occur during the reconciliation of Machines
 	// can be added as events to the Machine object and/or logged in the
@@ -217,12 +213,12 @@ type TinkerbellMachineInitializationStatus struct {
 }
 
 // GetConditions returns the conditions for the TinkerbellMachine.
-func (m *TinkerbellMachine) GetConditions() clusterv1.Conditions {
+func (m *TinkerbellMachine) GetConditions() []metav1.Condition {
 	return m.Status.Conditions
 }
 
 // SetConditions sets the conditions on the TinkerbellMachine.
-func (m *TinkerbellMachine) SetConditions(conditions clusterv1.Conditions) {
+func (m *TinkerbellMachine) SetConditions(conditions []metav1.Condition) {
 	m.Status.Conditions = conditions
 }
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,8 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -216,7 +217,7 @@ func (in *TinkerbellClusterStatus) DeepCopyInto(out *TinkerbellClusterStatus) {
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make(v1beta2.Conditions, len(*in))
+		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -343,7 +344,7 @@ func (in *TinkerbellMachineStatus) DeepCopyInto(out *TinkerbellMachineStatus) {
 	}
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
-		*out = make([]v1.NodeAddress, len(*in))
+		*out = make([]corev1.NodeAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.InstanceStatus != nil {
@@ -353,7 +354,7 @@ func (in *TinkerbellMachineStatus) DeepCopyInto(out *TinkerbellMachineStatus) {
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make(v1beta2.Conditions, len(*in))
+		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellclusters.yaml
@@ -136,51 +136,56 @@ spec:
               conditions:
                 description: Conditions defines current service state of the TinkerbellCluster.
                 items:
-                  description: Condition defines an observation of a Cluster API resource
-                    operational state.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
                         lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
                         message is a human readable message indicating details about the transition.
-                        This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may be empty.
-                      maxLength: 256
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
                       minLength: 1
-                      type: string
-                    severity:
-                      description: |-
-                        severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
-                      maxLength: 32
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
                   - lastTransitionTime
+                  - message
+                  - reason
                   - status
                   - type
                   type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -466,57 +466,58 @@ spec:
                   type: object
                 type: array
               conditions:
-                description: |-
-                  Conditions defines current service state of the TinkerbellMachine.
-                  Required to satisfy the Cluster API conditions.Getter/conditions.Setter
-                  interface contract. The CAPI framework may call GetConditions/SetConditions
-                  via interface assertion.
+                description: Conditions defines current service state of the TinkerbellMachine.
                 items:
-                  description: Condition defines an observation of a Cluster API resource
-                    operational state.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
                         lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
                         message is a human readable message indicating details about the transition.
-                        This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may be empty.
-                      maxLength: 256
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
                       minLength: 1
-                      type: string
-                    severity:
-                      description: |-
-                        severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
-                      maxLength: 32
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
                   - lastTransitionTime
+                  - message
+                  - reason
                   - status
                   - type
                   type: object

--- a/controller/cluster/tinkerbellcluster.go
+++ b/controller/cluster/tinkerbellcluster.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -257,28 +257,24 @@ func (tcr *TinkerbellClusterReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	isPaused, _, err := paused.EnsurePausedCondition(ctx, tcr.Client, crc.cluster, crc.tinkerbellCluster)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensuring paused condition: %w", err)
+	}
+
+	if isPaused {
+		crc.log.Info("TinkerbellCluster is paused, skipping reconciliation")
+
+		return ctrl.Result{}, nil
+	}
+
 	if !crc.tinkerbellCluster.DeletionTimestamp.IsZero() {
-		if annotations.HasPaused(crc.tinkerbellCluster) {
-			crc.log.Info("TinkerbellCluster is marked as paused. Won't reconcile deletion")
-
-			return ctrl.Result{}, nil
-		}
-
 		crc.log.Info("Removing cluster")
 
 		return ctrl.Result{}, crc.reconcileDelete()
 	}
 
 	if crc.cluster == nil {
-		return ctrl.Result{}, nil
-	}
-
-	// TODO(enhancement): Currently using simple annotation-based pause checking. Need to implement
-	// proper pause handling using paused.EnsurePausedCondition() as per:
-	// https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-cluster#infracluster-pausing
-	if annotations.IsPaused(crc.cluster, crc.tinkerbellCluster) {
-		crc.log.Info("TinkerbellCluster is marked as paused. Won't reconcile")
-
 		return ctrl.Result{}, nil
 	}
 
@@ -299,12 +295,12 @@ func (tcr *TinkerbellClusterReconciler) SetupWithManager(ctx context.Context, mg
 	builder := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
 		For(&infrastructurev1.TinkerbellCluster{}).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(sm, log, tcr.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(sm, log, tcr.WatchFilterValue)).
 		WithEventFilter(predicates.ResourceIsNotExternallyManaged(sm, log)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(mapper),
-			builder.WithPredicates(predicates.ClusterUnpaused(sm, log)),
+			builder.WithPredicates(predicates.ClusterPausedTransitionsOrInfrastructureProvisioned(sm, log)),
 		)
 
 	if err := builder.Complete(tcr); err != nil {

--- a/controller/cluster/tinkerbellcluster_test.go
+++ b/controller/cluster/tinkerbellcluster_test.go
@@ -210,6 +210,9 @@ func Test_Cluster_reconciliation(t *testing.T) {
 		// Requeue happens through watch of Cluster.
 		t.Run("cluster_is_paused", clusterReconciliationIsNotRequeuedWhenClusterIsPaused)
 
+		// Unpausing a previously paused cluster should resume reconciliation.
+		t.Run("cluster_is_unpaused", clusterReconciliationSetsNotPausedConditionWhenUnpaused)
+
 		// From https://cluster-api.sigs.k8s.io/developer/providers/cluster-infrastructure.html#behavior.
 		// This will be automatically requeued when the ownerRef is set.
 		t.Run("cluster_has_no_owner_set", clusterReconciliationIsNotRequeuedWhenClusterHasNoOwnerSet)
@@ -374,10 +377,19 @@ func clusterReconciliationIsNotRequeuedWhenTinkerbellClusterIsPaused(t *testing.
 		pausedTinkerbellCluster,
 	}
 
-	result, err := reconcileClusterWithClient(kubernetesClientWithObjects(t, objects), clusterName, clusterNamespace)
-	g.Expect(err).NotTo(HaveOccurred(), "Reconciling new cluster object should not fail when tinkerbellCluster is paused")
+	k8sClient := kubernetesClientWithObjects(t, objects)
 
-	g.Expect(result.IsZero()).To(BeTrue(), "Expected result to not request requeue")
+	result, err := reconcileClusterWithClient(k8sClient, clusterName, clusterNamespace)
+	g.Expect(err).NotTo(HaveOccurred(), "Reconciling should not fail when tinkerbellCluster is paused")
+	g.Expect(result.IsZero()).To(BeTrue(), "Expected no requeue when paused")
+
+	updatedTinkerbellCluster := &infrastructurev1.TinkerbellCluster{}
+	g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, updatedTinkerbellCluster)).To(Succeed())
+
+	pausedCondition := findCondition(updatedTinkerbellCluster.GetConditions(), clusterv1.PausedCondition)
+	g.Expect(pausedCondition).NotTo(BeNil(), "Expected Paused condition to be set")
+	g.Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue), "Expected Paused condition to be True")
+	g.Expect(pausedCondition.Reason).To(Equal(clusterv1.PausedReason), "Expected Paused reason")
 }
 
 func clusterReconciliationIsNotRequeuedWhenClusterIsPaused(t *testing.T) {
@@ -392,8 +404,52 @@ func clusterReconciliationIsNotRequeuedWhenClusterIsPaused(t *testing.T) {
 		validTinkerbellCluster(clusterName, clusterNamespace),
 	}
 
-	result, err := reconcileClusterWithClient(kubernetesClientWithObjects(t, objects), clusterName, clusterNamespace)
-	g.Expect(err).NotTo(HaveOccurred(), "Reconciling new cluster object should not fail when tinkerbellCluster is paused")
+	k8sClient := kubernetesClientWithObjects(t, objects)
 
-	g.Expect(result.IsZero()).To(BeTrue(), "Expected result to not request requeue")
+	result, err := reconcileClusterWithClient(k8sClient, clusterName, clusterNamespace)
+	g.Expect(err).NotTo(HaveOccurred(), "Reconciling should not fail when cluster is paused")
+	g.Expect(result.IsZero()).To(BeTrue(), "Expected no requeue when paused")
+
+	updatedTinkerbellCluster := &infrastructurev1.TinkerbellCluster{}
+	g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, updatedTinkerbellCluster)).To(Succeed())
+
+	pausedCondition := findCondition(updatedTinkerbellCluster.GetConditions(), clusterv1.PausedCondition)
+	g.Expect(pausedCondition).NotTo(BeNil(), "Expected Paused condition to be set")
+	g.Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue), "Expected Paused condition to be True")
+	g.Expect(pausedCondition.Reason).To(Equal(clusterv1.PausedReason), "Expected Paused reason")
+}
+
+func clusterReconciliationSetsNotPausedConditionWhenUnpaused(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	objects := []runtime.Object{
+		validCluster(clusterName, clusterNamespace),
+		validTinkerbellCluster(clusterName, clusterNamespace),
+	}
+
+	k8sClient := kubernetesClientWithObjects(t, objects)
+
+	result, err := reconcileClusterWithClient(k8sClient, clusterName, clusterNamespace)
+	g.Expect(err).NotTo(HaveOccurred(), "Reconciling should not fail when cluster is not paused")
+	g.Expect(result.IsZero()).To(BeTrue(), "Expected no requeue for normal reconciliation")
+
+	updatedTinkerbellCluster := &infrastructurev1.TinkerbellCluster{}
+	g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, updatedTinkerbellCluster)).To(Succeed())
+
+	pausedCondition := findCondition(updatedTinkerbellCluster.GetConditions(), clusterv1.PausedCondition)
+	g.Expect(pausedCondition).NotTo(BeNil(), "Expected Paused condition to be set")
+	g.Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse), "Expected Paused condition to be False")
+	g.Expect(pausedCondition.Reason).To(Equal(clusterv1.NotPausedReason), "Expected NotPaused reason")
+}
+
+// findCondition returns the condition with the given type, or nil if not found.
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+
+	return nil
 }

--- a/controller/machine/scope.go
+++ b/controller/machine/scope.go
@@ -367,32 +367,6 @@ func (scope *machineReconcileScope) patch() error {
 	return nil
 }
 
-// getReadyMachine returns valid ClusterAPI Machine object.
-//
-// If error occurs while fetching the machine, error is returned.
-//
-// If machine is not ready yet, nil is returned.
-func (scope *machineReconcileScope) getReadyMachine() (*clusterv1.Machine, error) {
-	// Continue building the context with some validation rules.
-	machine, err := util.GetOwnerMachine(scope.ctx, scope.client, scope.tinkerbellMachine.ObjectMeta)
-	if err != nil {
-		return nil, fmt.Errorf("getting Machine object: %w", err)
-	}
-
-	reason, err := isMachineReady(machine)
-	if err != nil {
-		return nil, fmt.Errorf("validating Machine object: %w", err)
-	}
-
-	if reason != "" {
-		scope.log.Info("machine is not ready yet", "reason", reason)
-
-		return nil, nil
-	}
-
-	return machine, nil
-}
-
 // isMachineReady validates that given Machine object is ready for further processing.
 //
 // If machine is not ready, string reason is returned.

--- a/controller/machine/tinkerbellmachine.go
+++ b/controller/machine/tinkerbellmachine.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -121,29 +121,42 @@ func (r *TinkerbellMachineReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	scope.patchHelper = patchHelper
 
-	// We must be bound to a CAPI Machine object before we can continue.
-	machine, err := scope.getReadyMachine()
+	// Resolve the owner Machine and Cluster before checking pause state.
+	// These may be nil if not yet assigned — EnsurePausedCondition handles a nil cluster
+	// by only checking the TinkerbellMachine's own paused annotation.
+	machine, err := util.GetOwnerMachine(ctx, scope.client, scope.tinkerbellMachine.ObjectMeta)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("getting valid Machine object: %w", err)
+		return ctrl.Result{}, fmt.Errorf("getting owner Machine: %w", err)
 	}
 
-	if machine == nil {
-		return ctrl.Result{}, nil
-	}
+	var cluster *clusterv1.Cluster
 
-	// Fetch the capi cluster owning the machine and check if the cluster is paused
-	cluster, err := util.GetClusterFromMetadata(ctx, scope.client, machine.ObjectMeta)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("getting cluster from metadata:: %w", err)
+	if machine != nil {
+		cluster, err = util.GetClusterFromMetadata(ctx, scope.client, machine.ObjectMeta)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("getting cluster from metadata: %w", err)
 		}
 	}
 
-	// TODO(enhancement): Currently using simple annotation-based pause checking. Need to implement
-	// proper pause handling using paused.EnsurePausedCondition() as per:
-	// https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-cluster#infracluster-pausing
-	if cluster != nil && annotations.IsPaused(cluster, scope.tinkerbellMachine) {
+	isPaused, _, err := paused.EnsurePausedCondition(ctx, r.Client, cluster, scope.tinkerbellMachine)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensuring paused condition: %w", err)
+	}
+
+	if isPaused {
 		log.Info("TinkerbellMachine is paused, skipping reconciliation")
+
+		return ctrl.Result{}, nil
+	}
+
+	// Validate the Machine is ready for full reconciliation.
+	reason, err := isMachineReady(machine)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("validating Machine object: %w", err)
+	}
+
+	if reason != "" {
+		log.Info("machine is not ready yet", "reason", reason)
 
 		return ctrl.Result{}, nil
 	}
@@ -198,7 +211,7 @@ func (r *TinkerbellMachineReconciler) SetupWithManager(ctx context.Context, mgr 
 
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(sm, log, r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(sm, log, r.WatchFilterValue)).
 		For(&infrastructurev1.TinkerbellMachine{}).
 		Watches(
 			&clusterv1.Machine{},

--- a/controller/machine/tinkerbellmachine_test.go
+++ b/controller/machine/tinkerbellmachine_test.go
@@ -1648,3 +1648,151 @@ tasks:
 		"Expected template data to match referenced template, diff: %s",
 		cmp.Diff(refTemplateData, *template.Spec.Data))
 }
+
+func Test_Machine_reconciliation_pausing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets_paused_condition_when_machine_has_paused_annotation", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hardwareUUID := uuid.New().String()
+
+		pausedMachine := validTinkerbellMachine(tinkerbellMachineName, clusterNamespace, machineName, hardwareUUID)
+		pausedMachine.Annotations = map[string]string{
+			clusterv1.PausedAnnotation: "true",
+		}
+
+		objects := []runtime.Object{
+			pausedMachine,
+			validCluster(clusterName, clusterNamespace),
+			validTinkerbellCluster(clusterName, clusterNamespace),
+			validHardware(hardwareName, hardwareUUID, hardwareIP),
+			validMachine(machineName, clusterNamespace, clusterName),
+			validSecret(machineName, clusterNamespace),
+		}
+
+		k8sClient := kubernetesClientWithObjects(t, objects)
+
+		result, err := reconcileMachineWithClient(k8sClient, tinkerbellMachineName, clusterNamespace)
+		g.Expect(err).NotTo(HaveOccurred(), "Reconciling should not fail when machine is paused")
+		g.Expect(result.IsZero()).To(BeTrue(), "Expected no requeue when paused")
+
+		updatedMachine := &infrastructurev1.TinkerbellMachine{}
+		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: tinkerbellMachineName, Namespace: clusterNamespace}, updatedMachine)).To(Succeed())
+
+		pausedCondition := findCondition(updatedMachine.GetConditions(), clusterv1.PausedCondition)
+		g.Expect(pausedCondition).NotTo(BeNil(), "Expected Paused condition to be set")
+		g.Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue), "Expected Paused condition to be True")
+		g.Expect(pausedCondition.Reason).To(Equal(clusterv1.PausedReason), "Expected Paused reason")
+	})
+
+	t.Run("sets_paused_condition_when_machine_has_paused_annotation_without_owner", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		// TinkerbellMachine with paused annotation but no OwnerRef (Machine not yet assigned).
+		pausedMachine := &infrastructurev1.TinkerbellMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tinkerbellMachineName,
+				Namespace: clusterNamespace,
+				Annotations: map[string]string{
+					clusterv1.PausedAnnotation: "true",
+				},
+			},
+		}
+
+		objects := []runtime.Object{
+			pausedMachine,
+		}
+
+		k8sClient := kubernetesClientWithObjects(t, objects)
+
+		result, err := reconcileMachineWithClient(k8sClient, tinkerbellMachineName, clusterNamespace)
+		g.Expect(err).NotTo(HaveOccurred(), "Reconciling should not fail when machine is paused without owner")
+		g.Expect(result.IsZero()).To(BeTrue(), "Expected no requeue when paused")
+
+		updatedMachine := &infrastructurev1.TinkerbellMachine{}
+		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: tinkerbellMachineName, Namespace: clusterNamespace}, updatedMachine)).To(Succeed())
+
+		pausedCondition := findCondition(updatedMachine.GetConditions(), clusterv1.PausedCondition)
+		g.Expect(pausedCondition).NotTo(BeNil(), "Expected Paused condition to be set even without owner Machine")
+		g.Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue), "Expected Paused condition to be True")
+		g.Expect(pausedCondition.Reason).To(Equal(clusterv1.PausedReason), "Expected Paused reason")
+	})
+
+	t.Run("sets_paused_condition_when_cluster_is_paused", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hardwareUUID := uuid.New().String()
+
+		pausedCluster := validCluster(clusterName, clusterNamespace)
+		pausedCluster.Spec.Paused = ptr.To(true)
+
+		objects := []runtime.Object{
+			validTinkerbellMachine(tinkerbellMachineName, clusterNamespace, machineName, hardwareUUID),
+			pausedCluster,
+			validTinkerbellCluster(clusterName, clusterNamespace),
+			validHardware(hardwareName, hardwareUUID, hardwareIP),
+			validMachine(machineName, clusterNamespace, clusterName),
+			validSecret(machineName, clusterNamespace),
+		}
+
+		k8sClient := kubernetesClientWithObjects(t, objects)
+
+		result, err := reconcileMachineWithClient(k8sClient, tinkerbellMachineName, clusterNamespace)
+		g.Expect(err).NotTo(HaveOccurred(), "Reconciling should not fail when cluster is paused")
+		g.Expect(result.IsZero()).To(BeTrue(), "Expected no requeue when paused")
+
+		updatedMachine := &infrastructurev1.TinkerbellMachine{}
+		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: tinkerbellMachineName, Namespace: clusterNamespace}, updatedMachine)).To(Succeed())
+
+		pausedCondition := findCondition(updatedMachine.GetConditions(), clusterv1.PausedCondition)
+		g.Expect(pausedCondition).NotTo(BeNil(), "Expected Paused condition to be set")
+		g.Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue), "Expected Paused condition to be True")
+		g.Expect(pausedCondition.Reason).To(Equal(clusterv1.PausedReason), "Expected Paused reason")
+	})
+
+	t.Run("sets_not_paused_condition_when_not_paused", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hardwareUUID := uuid.New().String()
+
+		objects := []runtime.Object{
+			validTinkerbellMachine(tinkerbellMachineName, clusterNamespace, machineName, hardwareUUID),
+			validCluster(clusterName, clusterNamespace),
+			validTinkerbellCluster(clusterName, clusterNamespace),
+			validHardware(hardwareName, hardwareUUID, hardwareIP),
+			validMachine(machineName, clusterNamespace, clusterName),
+			validSecret(machineName, clusterNamespace),
+		}
+
+		k8sClient := kubernetesClientWithObjects(t, objects)
+
+		_, err := reconcileMachineWithClient(k8sClient, tinkerbellMachineName, clusterNamespace)
+		g.Expect(err).NotTo(HaveOccurred(), "Reconciling should not fail")
+
+		updatedMachine := &infrastructurev1.TinkerbellMachine{}
+		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: tinkerbellMachineName, Namespace: clusterNamespace}, updatedMachine)).To(Succeed())
+
+		pausedCondition := findCondition(updatedMachine.GetConditions(), clusterv1.PausedCondition)
+		g.Expect(pausedCondition).NotTo(BeNil(), "Expected Paused condition to be set")
+		g.Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse), "Expected Paused condition to be False")
+		g.Expect(pausedCondition.Reason).To(Equal(clusterv1.NotPausedReason), "Expected NotPaused reason")
+	})
+}
+
+// findCondition returns the condition with the given type, or nil if not found.
+//
+//nolint:unparam
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+
+	return nil
+}

--- a/docs/PAUSING.md
+++ b/docs/PAUSING.md
@@ -1,0 +1,62 @@
+# Pausing Clusters and Machines
+
+Pausing prevents CAPT from reconciling infrastructure resources. This is useful during maintenance, debugging, or when you need to make manual changes without the controller reverting them.
+
+## Pausing a Cluster
+
+Pausing a `Cluster` pauses all associated infrastructure resources (`TinkerbellCluster` and `TinkerbellMachine`).
+
+```sh
+kubectl annotate cluster <cluster-name> cluster.x-k8s.io/paused=""
+```
+
+Or set `spec.paused` on the Cluster:
+
+```sh
+kubectl patch cluster <cluster-name> --type merge -p '{"spec":{"paused":true}}'
+```
+
+## Pausing a Single Machine
+
+To pause a specific `TinkerbellMachine` without affecting the rest of the cluster:
+
+```sh
+kubectl annotate tinkerbellmachine <machine-name> cluster.x-k8s.io/paused=""
+```
+
+## Checking Pause Status
+
+When paused, a `Paused` condition is set on the resource:
+
+```sh
+kubectl get tinkerbellcluster <name> -o jsonpath='{.status.conditions[?(@.type=="Paused")]}'
+kubectl get tinkerbellmachine <name> -o jsonpath='{.status.conditions[?(@.type=="Paused")]}'
+```
+
+A paused resource shows `status: "True"` with `reason: Paused`.
+
+## Unpausing
+
+Remove the annotation:
+
+```sh
+kubectl annotate cluster <cluster-name> cluster.x-k8s.io/paused-
+kubectl annotate tinkerbellmachine <machine-name> cluster.x-k8s.io/paused-
+```
+
+Or unset `spec.paused`:
+
+```sh
+kubectl patch cluster <cluster-name> --type merge -p '{"spec":{"paused":false}}'
+```
+
+The `Paused` condition will update to `status: "False"` with `reason: NotPaused`, and reconciliation resumes.
+
+## What Pausing Blocks
+
+- Creation and deletion of Tinkerbell Templates, Workflows, and BMC Jobs
+- Hardware selection and provisioning
+- Provider reconciliation and status progression on `TinkerbellCluster` and `TinkerbellMachine`
+- Deletion reconciliation (finalizer removal is deferred until unpaused)
+
+Note: The `Paused` condition itself is always written and updated, even while paused. Only provider-specific reconciliation and status progression are deferred.


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The v1beta2 CAPI contract recommends surfacing pause state via a Paused condition on infrastructure resources. Previously, both controllers only checked annotations and returned early without setting any condition, making pause state invisible to users and tooling.

Replace annotation-based checks with paused.EnsurePausedCondition(), which atomically sets a Paused condition (True/False) on the resource. Update watch predicates so controllers reconcile on pause transitions (not just unpause), enabling the condition to be set promptly.

Migrate the Conditions field from the deprecated clusterv1.Condition type to standard metav1.Condition, which is required by the conditions.Setter interface that EnsurePausedCondition depends on.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
