### PR TITLE
fix: claim Hardware with optimistic concurrency to avoid duplicate ownership

### DIFF
--- a/controller/machine/hardware.go
+++ b/controller/machine/hardware.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -53,6 +54,9 @@ var (
 	// ErrHardwareMissingDiskConfiguration is returned when the referenced hardware is missing
 	// disk configuration.
 	ErrHardwareMissingDiskConfiguration = fmt.Errorf("disk configuration is required")
+	// errHardwareClaimRequeue marks expected claim contention that should be retried
+	// without surfacing a reconciliation error.
+	errHardwareClaimRequeue = errors.New("hardware claim requires requeue")
 )
 
 // hardwareIP returns the IP address of the first network interface of the given hardware.
@@ -102,18 +106,37 @@ func (scope *machineReconcileScope) patchHardwareAnnotations(hw *tinkv1.Hardware
 	return nil
 }
 
+// hardwareAlreadyClaimed reports whether hw already carries this Machine's ownership
+// labels and the expected finalizer state, i.e. a claim would have nothing to write.
+func (scope *machineReconcileScope) hardwareAlreadyClaimed(hw *tinkv1.Hardware) bool {
+	return hw.Labels[HardwareOwnerNameLabel] == scope.tinkerbellMachine.Name &&
+		hw.Labels[HardwareOwnerNamespaceLabel] == scope.tinkerbellMachine.Namespace &&
+		controllerutil.ContainsFinalizer(hw, infrastructurev1.MachineFinalizer) &&
+		!controllerutil.ContainsFinalizer(hw, infrastructurev1.MachineLegacyFinalizer)
+}
+
 func (scope *machineReconcileScope) takeHardwareOwnership(hw *tinkv1.Hardware) error {
-	// hardwareForMachine() lists only unowned Hardware and returns the first element
-	// after a deterministic sort, so two Machines reconciling concurrently can select
-	// the SAME Hardware. Guard against claiming one already owned by a different
-	// Machine: back off and requeue so the next pass re-lists (this Hardware is now
-	// filtered out by the DoesNotExist owner selector) and picks a still-free one.
+	// hardwareForMachine() returns already-assigned Hardware for this Machine first,
+	// otherwise lists unowned Hardware and returns the first element after a
+	// deterministic sort — so two Machines reconciling concurrently can still select
+	// the SAME unowned Hardware. Guard against claiming one already owned by a
+	// different Machine: back off and requeue so the next pass re-lists (this Hardware
+	// is now filtered out by the DoesNotExist owner selector) and picks a still-free one.
 	if owner, ok := hw.Labels[HardwareOwnerNameLabel]; ok &&
 		(owner != scope.tinkerbellMachine.Name ||
 			hw.Labels[HardwareOwnerNamespaceLabel] != scope.tinkerbellMachine.Namespace) {
-		return fmt.Errorf("hardware %q already owned by %s/%s, requeuing to select free hardware",
+		return fmt.Errorf("%w: hardware %q already owned by %s/%s",
+			errHardwareClaimRequeue,
 			hw.Name, hw.Labels[HardwareOwnerNamespaceLabel], owner)
 	}
+
+	// Already claimed by this Machine with the expected finalizer state: nothing to
+	// write. Skipping the no-op patch avoids bumping resourceVersion on every
+	// reconcile and the avoidable conflicts that causes for other writers.
+	if scope.hardwareAlreadyClaimed(hw) {
+		return nil
+	}
+	base := hw.DeepCopy()
 
 	if hw.Labels == nil {
 		hw.Labels = map[string]string{}
@@ -127,15 +150,14 @@ func (scope *machineReconcileScope) takeHardwareOwnership(hw *tinkv1.Hardware) e
 	controllerutil.RemoveFinalizer(hw, infrastructurev1.MachineLegacyFinalizer)
 	controllerutil.AddFinalizer(hw, infrastructurev1.MachineFinalizer)
 
-	// Claim with optimistic concurrency: Update carries the ResourceVersion read by
-	// hardwareForMachine's List, so a losing concurrent claim of the same Hardware
-	// gets a Conflict instead of silently overwriting the winner's ownership (the
-	// former left one Machine unbound and another Hardware unclaimed). Requeue on
-	// conflict to re-list and select a still-free Hardware. A plain patch merged
-	// without a precondition, which is why concurrent claims used to both succeed.
-	if err := scope.tinkerbellClient.Update(scope.ctx, hw); err != nil {
+	// Claim with an optimistic-lock merge patch. This keeps the write limited to
+	// ownership labels and finalizers while carrying the ResourceVersion read by
+	// hardwareForMachine. A losing concurrent claim gets a Conflict instead of
+	// silently overwriting the winner's ownership.
+	claimPatch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
+	if err := scope.tinkerbellClient.Patch(scope.ctx, hw, claimPatch); err != nil {
 		if apierrors.IsConflict(err) {
-			return fmt.Errorf("conflict claiming hardware %q (concurrent claim), requeuing: %w", hw.Name, err)
+			return fmt.Errorf("%w: conflict claiming hardware %q: %w", errHardwareClaimRequeue, hw.Name, err)
 		}
 
 		return fmt.Errorf("claiming Hardware ownership: %w", err)

--- a/controller/machine/hardware.go
+++ b/controller/machine/hardware.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	tinkv1 "github.com/tinkerbell/tinkerbell/api/v1alpha1/tinkerbell"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -102,9 +103,16 @@ func (scope *machineReconcileScope) patchHardwareAnnotations(hw *tinkv1.Hardware
 }
 
 func (scope *machineReconcileScope) takeHardwareOwnership(hw *tinkv1.Hardware) error {
-	patchHelper, err := patch.NewHelper(hw, scope.tinkerbellClient)
-	if err != nil {
-		return fmt.Errorf("initializing patch helper for selected hardware: %w", err)
+	// hardwareForMachine() lists only unowned Hardware and returns the first element
+	// after a deterministic sort, so two Machines reconciling concurrently can select
+	// the SAME Hardware. Guard against claiming one already owned by a different
+	// Machine: back off and requeue so the next pass re-lists (this Hardware is now
+	// filtered out by the DoesNotExist owner selector) and picks a still-free one.
+	if owner, ok := hw.Labels[HardwareOwnerNameLabel]; ok &&
+		(owner != scope.tinkerbellMachine.Name ||
+			hw.Labels[HardwareOwnerNamespaceLabel] != scope.tinkerbellMachine.Namespace) {
+		return fmt.Errorf("hardware %q already owned by %s/%s, requeuing to select free hardware",
+			hw.Name, hw.Labels[HardwareOwnerNamespaceLabel], owner)
 	}
 
 	if hw.Labels == nil {
@@ -119,8 +127,18 @@ func (scope *machineReconcileScope) takeHardwareOwnership(hw *tinkv1.Hardware) e
 	controllerutil.RemoveFinalizer(hw, infrastructurev1.MachineLegacyFinalizer)
 	controllerutil.AddFinalizer(hw, infrastructurev1.MachineFinalizer)
 
-	if err := patchHelper.Patch(scope.ctx, hw); err != nil {
-		return fmt.Errorf("patching Hardware object: %w", err)
+	// Claim with optimistic concurrency: Update carries the ResourceVersion read by
+	// hardwareForMachine's List, so a losing concurrent claim of the same Hardware
+	// gets a Conflict instead of silently overwriting the winner's ownership (the
+	// former left one Machine unbound and another Hardware unclaimed). Requeue on
+	// conflict to re-list and select a still-free Hardware. A plain patch merged
+	// without a precondition, which is why concurrent claims used to both succeed.
+	if err := scope.tinkerbellClient.Update(scope.ctx, hw); err != nil {
+		if apierrors.IsConflict(err) {
+			return fmt.Errorf("conflict claiming hardware %q (concurrent claim), requeuing: %w", hw.Name, err)
+		}
+
+		return fmt.Errorf("claiming Hardware ownership: %w", err)
 	}
 
 	return nil

--- a/controller/machine/hardware_test.go
+++ b/controller/machine/hardware_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2022 The Tinkerbell Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine //nolint:testpackage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega" //nolint:revive // one day we will remove gomega
+	tinkv1 "github.com/tinkerbell/tinkerbell/api/v1alpha1/tinkerbell"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	infrastructurev1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
+)
+
+func hardwareTestScheme(g Gomega) *runtime.Scheme {
+	s := runtime.NewScheme()
+	g.Expect(infrastructurev1.AddToScheme(s)).To(Succeed())
+
+	sb := &scheme.Builder{GroupVersion: tinkv1.GroupVersion}
+	sb.Register(&tinkv1.Hardware{}, &tinkv1.HardwareList{})
+	g.Expect(sb.AddToScheme(s)).To(Succeed())
+
+	return s
+}
+
+func newHardwareTestClient(g Gomega, objects ...client.Object) client.Client {
+	s := hardwareTestScheme(g)
+
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objects...).
+		WithStatusSubresource(&tinkv1.Hardware{}).
+		Build()
+}
+
+// blockingPatchClient pauses Patch calls until two claimers have reached the
+// write boundary. This makes the read-modify-write race deterministic.
+type blockingPatchClient struct {
+	client.Client
+	entered chan struct{}
+	release chan struct{}
+	patches atomic.Int32
+	once    sync.Once
+}
+
+func (c *blockingPatchClient) Patch(
+	ctx context.Context,
+	obj client.Object,
+	patch client.Patch,
+	opts ...client.PatchOption,
+) error {
+	if c.patches.Add(1) == 2 {
+		c.once.Do(func() {
+			close(c.entered)
+		})
+	}
+
+	<-c.release
+	if err := c.Client.Patch(ctx, obj, patch, opts...); err != nil {
+		return fmt.Errorf("patching object after claim barrier: %w", err)
+	}
+
+	return nil
+}
+
+// Test_takeHardwareOwnership_owned_by_other_machine asserts that takeHardwareOwnership
+// refuses to claim Hardware already labelled as owned by a different Machine, returning
+// an error and leaving the object untouched (no resourceVersion bump).
+func Test_takeHardwareOwnership_owned_by_other_machine(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	const (
+		machineName      = "myMachine"
+		machineNamespace = "myNamespace"
+		hardwareName     = "myHardware"
+	)
+
+	hw := &tinkv1.Hardware{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hardwareName,
+			Namespace: machineNamespace,
+			Labels: map[string]string{
+				HardwareOwnerNameLabel:      "otherMachine",
+				HardwareOwnerNamespaceLabel: "otherNamespace",
+			},
+		},
+	}
+
+	cl := newHardwareTestClient(g, hw)
+
+	scope := &machineReconcileScope{
+		ctx:               context.Background(),
+		tinkerbellClient:  cl,
+		tinkerbellMachine: &infrastructurev1.TinkerbellMachine{ObjectMeta: metav1.ObjectMeta{Name: machineName, Namespace: machineNamespace}},
+	}
+	before := &tinkv1.Hardware{}
+	g.Expect(cl.Get(context.Background(), types.NamespacedName{Name: hardwareName, Namespace: machineNamespace}, before)).To(Succeed())
+
+	err := scope.takeHardwareOwnership(hw)
+	g.Expect(err).To(HaveOccurred(), "expected error claiming Hardware owned by a different Machine")
+	g.Expect(errors.Is(err, errHardwareClaimRequeue)).To(BeTrue(),
+		"expected ownership contention to request a quiet requeue")
+	g.Expect(err.Error()).To(ContainSubstring("already owned"), "expected 'already owned' guard error")
+
+	// The object must not have been written: a fresh Get yields the same resourceVersion.
+	persisted := &tinkv1.Hardware{}
+	g.Expect(cl.Get(context.Background(), types.NamespacedName{Name: hardwareName, Namespace: machineNamespace}, persisted)).To(Succeed())
+	g.Expect(persisted.ResourceVersion).To(Equal(before.ResourceVersion),
+		"Hardware must not be written when it already belongs to another Machine")
+	g.Expect(persisted.Labels[HardwareOwnerNameLabel]).To(Equal("otherMachine"),
+		"Hardware must keep its original owner label, not be claimed by this Machine")
+}
+
+// Test_takeHardwareOwnership_already_claimed_is_noop asserts that when Hardware is already
+// claimed by this Machine with the expected finalizer state, takeHardwareOwnership is a
+// no-op: it returns nil without bumping resourceVersion (avoids avoidable conflicts).
+func Test_takeHardwareOwnership_already_claimed_is_noop(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	const (
+		machineName      = "myMachine"
+		machineNamespace = "myNamespace"
+		hardwareName     = "myHardware"
+	)
+
+	hw := &tinkv1.Hardware{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hardwareName,
+			Namespace: machineNamespace,
+			Labels: map[string]string{
+				HardwareOwnerNameLabel:      machineName,
+				HardwareOwnerNamespaceLabel: machineNamespace,
+			},
+		},
+	}
+	controllerutil.AddFinalizer(hw, infrastructurev1.MachineFinalizer)
+
+	cl := newHardwareTestClient(g, hw)
+
+	scope := &machineReconcileScope{
+		ctx:               context.Background(),
+		tinkerbellClient:  cl,
+		tinkerbellMachine: &infrastructurev1.TinkerbellMachine{ObjectMeta: metav1.ObjectMeta{Name: machineName, Namespace: machineNamespace}},
+	}
+
+	before := &tinkv1.Hardware{}
+	g.Expect(cl.Get(context.Background(), types.NamespacedName{Name: hardwareName, Namespace: machineNamespace}, before)).To(Succeed())
+
+	g.Expect(scope.takeHardwareOwnership(hw)).To(Succeed(), "already-claimed Hardware should be a no-op, not an error")
+
+	after := &tinkv1.Hardware{}
+	g.Expect(cl.Get(context.Background(), types.NamespacedName{Name: hardwareName, Namespace: machineNamespace}, after)).To(Succeed())
+	g.Expect(after.ResourceVersion).To(Equal(before.ResourceVersion),
+		"already-claimed Hardware must not be rewritten on subsequent reconciles")
+}
+
+// Test_takeHardwareOwnership_concurrent_claims verifies that two Machines which
+// read the same Hardware resourceVersion cannot both claim it. The barrier
+// forces both stale objects to reach Patch before either write is allowed.
+func Test_takeHardwareOwnership_concurrent_claims(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	const (
+		hardwareName      = "myHardware"
+		machineNamespace  = "myNamespace"
+		firstMachineName  = "firstMachine"
+		secondMachineName = "secondMachine"
+	)
+
+	hw := &tinkv1.Hardware{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hardwareName,
+			Namespace: machineNamespace,
+		},
+	}
+
+	baseClient := newHardwareTestClient(g, hw)
+	claimClient := &blockingPatchClient{
+		Client:  baseClient,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	firstHardware := &tinkv1.Hardware{}
+	secondHardware := &tinkv1.Hardware{}
+	namespacedName := types.NamespacedName{Name: hardwareName, Namespace: machineNamespace}
+	g.Expect(baseClient.Get(context.Background(), namespacedName, firstHardware)).To(Succeed())
+	g.Expect(baseClient.Get(context.Background(), namespacedName, secondHardware)).To(Succeed())
+	g.Expect(firstHardware.ResourceVersion).To(Equal(secondHardware.ResourceVersion))
+
+	scope := func(machineName string) *machineReconcileScope {
+		return &machineReconcileScope{
+			ctx:              context.Background(),
+			tinkerbellClient: claimClient,
+			tinkerbellMachine: &infrastructurev1.TinkerbellMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machineName,
+					Namespace: machineNamespace,
+				},
+			},
+		}
+	}
+
+	results := make(chan error, 2)
+	go func() {
+		results <- scope(firstMachineName).takeHardwareOwnership(firstHardware)
+	}()
+	go func() {
+		results <- scope(secondMachineName).takeHardwareOwnership(secondHardware)
+	}()
+
+	select {
+	case <-claimClient.entered:
+	case <-time.After(time.Second):
+		close(claimClient.release)
+		t.Fatal("timed out waiting for both concurrent claims to reach Patch")
+	}
+	close(claimClient.release)
+
+	firstErr := <-results
+	secondErr := <-results
+	errs := []error{firstErr, secondErr}
+
+	successes := 0
+	conflicts := 0
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case apierrors.IsConflict(err):
+			g.Expect(errors.Is(err, errHardwareClaimRequeue)).To(BeTrue(),
+				"expected concurrent claim conflict to request a quiet requeue")
+			conflicts++
+		default:
+			t.Fatalf("unexpected claim error: %v", err)
+		}
+	}
+
+	g.Expect(successes).To(Equal(1), "exactly one Machine must win the Hardware claim")
+	g.Expect(conflicts).To(Equal(1), "exactly one Machine must lose with a resourceVersion conflict")
+
+	persisted := &tinkv1.Hardware{}
+	g.Expect(baseClient.Get(context.Background(), namespacedName, persisted)).To(Succeed())
+	g.Expect([]string{firstMachineName, secondMachineName}).To(
+		ContainElement(persisted.Labels[HardwareOwnerNameLabel]),
+		"the persisted owner must be one of the competing Machines",
+	)
+}

--- a/controller/machine/tinkerbellmachine.go
+++ b/controller/machine/tinkerbellmachine.go
@@ -19,6 +19,7 @@ package machine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -192,8 +193,17 @@ func (r *TinkerbellMachineReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	scope.machine = machine
 	scope.bootstrapCloudConfig = bootstrapCloudConfig
 	scope.tinkerbellCluster = tinkerbellCluster
+	if err := scope.Reconcile(); err != nil {
+		if errors.Is(err, errHardwareClaimRequeue) {
+			log.V(4).Info("Hardware claim contention, requeuing", "error", err)
 
-	return ctrl.Result{}, scope.Reconcile()
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager configures reconciler with a given manager.

--- a/controller/machine/tinkerbellmachine_test.go
+++ b/controller/machine/tinkerbellmachine_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/gomega" //nolint:revive // one day we will remove gomega
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -293,6 +295,31 @@ func kubernetesClientWithObjects(t *testing.T, objects []runtime.Object) client.
 	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).WithStatusSubresource(objs...).Build()
 }
 
+type hardwarePatchConflictClient struct {
+	client.Client
+}
+
+func (c *hardwarePatchConflictClient) Patch(
+	ctx context.Context,
+	obj client.Object,
+	patch client.Patch,
+	opts ...client.PatchOption,
+) error {
+	if _, ok := obj.(*tinkv1.Hardware); ok {
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: tinkv1.GroupVersion.Group, Resource: "hardware"},
+			obj.GetName(),
+			fmt.Errorf("forced Hardware claim conflict"),
+		)
+	}
+
+	if err := c.Client.Patch(ctx, obj, patch, opts...); err != nil {
+		return fmt.Errorf("patching non-Hardware object: %w", err)
+	}
+
+	return nil
+}
+
 func testScheme(g Gomega) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
@@ -471,6 +498,84 @@ func Test_Machine_reconciliation_with_available_hardware(t *testing.T) {
 			t.Error(diff)
 		}
 	})
+}
+
+// Once the Hardware is claimed by the Machine, subsequent reconciles must not write it
+// again: an unnecessary write adds avoidable conflict opportunities for other writers.
+func Test_Machine_reconciliation_does_not_rewrite_already_claimed_hardware(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	hardwareUUID := uuid.New().String()
+
+	objects := []runtime.Object{
+		validTinkerbellMachine(tinkerbellMachineName, clusterNamespace, machineName, hardwareUUID),
+		validCluster(clusterName, clusterNamespace),
+		validTinkerbellCluster(clusterName, clusterNamespace),
+		validHardware(hardwareName, hardwareUUID, hardwareIP),
+		validMachine(machineName, clusterNamespace, clusterName),
+		validSecret(machineName, clusterNamespace),
+	}
+
+	client := kubernetesClientWithObjects(t, objects)
+
+	_, err := reconcileMachineWithClient(client, tinkerbellMachineName, clusterNamespace)
+	g.Expect(err).NotTo(HaveOccurred(), "Unexpected reconciliation error")
+
+	ctx := context.Background()
+
+	hardwareNamespacedName := types.NamespacedName{
+		Name:      hardwareName,
+		Namespace: clusterNamespace,
+	}
+
+	claimedHardware := &tinkv1.Hardware{}
+	g.Expect(client.Get(ctx, hardwareNamespacedName, claimedHardware)).To(Succeed())
+
+	_, err = reconcileMachineWithClient(client, tinkerbellMachineName, clusterNamespace)
+	g.Expect(err).NotTo(HaveOccurred(), "Unexpected reconciliation error")
+
+	reclaimedHardware := &tinkv1.Hardware{}
+	g.Expect(client.Get(ctx, hardwareNamespacedName, reclaimedHardware)).To(Succeed())
+
+	g.Expect(reclaimedHardware.ResourceVersion).To(Equal(claimedHardware.ResourceVersion),
+		"Expected already-claimed Hardware not to be rewritten on subsequent reconciles")
+}
+
+func Test_Machine_reconciliation_quietly_requeues_hardware_claim_conflict(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	hardwareUUID := uuid.New().String()
+	objects := []runtime.Object{
+		validTinkerbellMachine(tinkerbellMachineName, clusterNamespace, machineName, hardwareUUID),
+		validCluster(clusterName, clusterNamespace),
+		validTinkerbellCluster(clusterName, clusterNamespace),
+		validHardware(hardwareName, hardwareUUID, hardwareIP),
+		validMachine(machineName, clusterNamespace, clusterName),
+		validSecret(machineName, clusterNamespace),
+	}
+
+	managementClient := kubernetesClientWithObjects(t, objects)
+	tinkerbellClient := &hardwarePatchConflictClient{Client: managementClient}
+
+	result, err := reconcileMachineWithClients(
+		managementClient,
+		tinkerbellClient,
+		tinkerbellMachineName,
+		clusterNamespace,
+	)
+	g.Expect(err).NotTo(HaveOccurred(), "Expected Hardware claim conflict to requeue without an error")
+	g.Expect(result.RequeueAfter).To(BeNumerically(">", 0), "Expected an explicit delayed requeue")
+
+	persisted := &tinkv1.Hardware{}
+	g.Expect(managementClient.Get(
+		context.Background(),
+		types.NamespacedName{Name: hardwareName, Namespace: clusterNamespace},
+		persisted,
+	)).To(Succeed())
+	g.Expect(persisted.Labels).NotTo(HaveKey(machine.HardwareOwnerNameLabel),
+		"Expected failed claim not to persist an owner")
 }
 
 func Test_Machine_reconciliation_workflow_complete(t *testing.T) {
@@ -782,6 +887,15 @@ func machineReconciliationPanicsWhenReconcilerHasNoClientSet(t *testing.T) {
 
 //nolint:unparam
 func reconcileMachineWithClient(client client.Client, name, namespace string) (ctrl.Result, error) {
+	return reconcileMachineWithClients(client, client, name, namespace)
+}
+
+func reconcileMachineWithClients(
+	managementClient client.Client,
+	tinkerbellClient client.Client,
+	name,
+	namespace string,
+) (ctrl.Result, error) {
 	scheme := runtime.NewScheme()
 	_ = controller.AddToSchemeTinkerbell(scheme)
 	_ = infrastructurev1.AddToScheme(scheme)
@@ -789,8 +903,8 @@ func reconcileMachineWithClient(client client.Client, name, namespace string) (c
 	_ = corev1.AddToScheme(scheme)
 
 	machineController := &machine.TinkerbellMachineReconciler{
-		Client:           client,
-		TinkerbellClient: client,
+		Client:           managementClient,
+		TinkerbellClient: tinkerbellClient,
 		Scheme:           scheme,
 	}
 


### PR DESCRIPTION
Fixes #587.

## Description

Make `TinkerbellMachine` Hardware selection race-safe so two Machines reconciling
concurrently can't claim the same Hardware (leaving another unclaimed).

Fixes: #587.

### Why

`hardwareForMachine()` lists unowned Hardware, sorts it deterministically, and returns
`matchingHardware[0]`; `takeHardwareOwnership()` then sets the owner labels via an
unconditioned patch (no `resourceVersion` precondition). Concurrent reconciles read the
same unowned set, pick the same first element, and both writes succeed (last wins) — so
two Machines bind the same Hardware, a third Hardware is never claimed, `providerID` vs
the owner label end up permuted, and orphaned owner labels leak on teardown. The Cluster
never reaches `Available`. See #<ISSUE> for the full analysis.

### How

`controller/machine/hardware.go`, `takeHardwareOwnership()`:

- Guard: if the selected Hardware already carries `ownerName` for a *different* Machine,
  return an error to requeue instead of overwriting the existing owner.
- Claim with optimistic concurrency: replace the unconditioned `patchHelper.Patch` with
  `Update` (carries the `ResourceVersion` read during `hardwareForMachine`'s list), so a
  losing concurrent claim gets a `Conflict`. On conflict, requeue — the next reconcile
  re-lists (the now-owned Hardware is excluded by the `DoesNotExist` owner selector) and
  selects a still-free Hardware.

Both the owned-by-other guard and the conflict path return an error, so controller-runtime
requeues with backoff and the loser converges onto a free Hardware within a pass or two.


## How Has This Been Tested?

Staged in our CAPI -> CAPBT, CACPPT deployment (FYI image built and pushed to **`docker.io/xjjo/cluster-api-provider-tinkerbell:v0.7.0-fix-claim-hw-race`**):

* CAPI, CAPBT, CACPT running in cluster-A
* Tinkerbell deployed in cluster-B (cluster A->B networked and authnz'd)

Concurrent provisioning of N Machines against N eligible Hardware yields a stable 1:1 assignment; no duplicate claims, no unclaimed Hardware, no permuted `providerID`/owner labels, no orphaned owner labels on delete.

Without this fix, for a 3-CP + 6-WK cluster, we observed 2-3 orphaned Hardware owner labels on teardown, and the cluster never reached `Available` (_0% success_), requiring manual intervention to fix the labels.

Once deployed this fix, the cluster reached `Available` without duplicate/orphaned Hardware ownership across repeated redeploys (5+ times in a row, _100% success_).

## How are existing users impacted? What migration steps/scripts do we need?

Fixes: #587 _"Hardware claim is racy: concurrent TinkerbellMachine reconciles select the same Hardware"_

No migration needed.

## Notes

- No API/CRD change; behavior-only fix in the claim path.
- The guard + conflict both currently requeue via returned error (backoff). A quieter
  requeue (debug log + explicit requeue result) is an option if reviewers prefer.

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
