### PR TITLE
feat: mirror Hardware installer-image annotation into machine status

### DIFF
--- a/api/v1beta1/tinkerbellmachine_types.go
+++ b/api/v1beta1/tinkerbellmachine_types.go
@@ -173,6 +173,16 @@ type TinkerbellMachineStatus struct {
 	// +optional
 	TargetNamespace string `json:"targetNamespace,omitempty"`
 
+	// InstallerImage is the installer image resolved for this machine,
+	// mirrored from the bound Hardware's annotation
+	// (hardware.tinkerbell.org/installer-image). It lets infrastructure
+	// providers publish hardware-specific image knowledge (e.g. a Talos
+	// Image Factory ref carrying the right system extensions) for bootstrap
+	// providers to consume generically. Empty when the Hardware carries no
+	// annotation; consumers must treat an empty value as "no override".
+	// +optional
+	InstallerImage string `json:"installerImage,omitempty"`
+
 	// Conditions defines current service state of the TinkerbellMachine.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_tinkerbellmachines.yaml
@@ -559,6 +559,16 @@ spec:
                       NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Machine provisioning.
                     type: boolean
                 type: object
+              installerImage:
+                description: |-
+                  InstallerImage is the installer image resolved for this machine,
+                  mirrored from the bound Hardware's annotation
+                  (hardware.tinkerbell.org/installer-image). It lets infrastructure
+                  providers publish hardware-specific image knowledge (e.g. a Talos
+                  Image Factory ref carrying the right system extensions) for bootstrap
+                  providers to consume generically. Empty when the Hardware carries no
+                  annotation; consumers must treat an empty value as "no override".
+                type: string
               instanceStatus:
                 description: InstanceStatus is the status of the Tinkerbell device
                   instance for this machine.

--- a/controller/machine/hardware.go
+++ b/controller/machine/hardware.go
@@ -35,6 +35,13 @@ const (
 
 	// HardwareTemplateOverrideAnnotation can be used to override the default Template used for provisioning.
 	HardwareTemplateOverrideAnnotation = "hardware.tinkerbell.org/capt-template-override"
+
+	// HardwareInstallerImageAnnotation specifies the installer image
+	// (e.g. a Talos Image Factory ref with its schematic) for the machine
+	// bound to this Hardware. When set, the TinkerbellMachine controller
+	// mirrors it into status.installerImage so bootstrap providers can
+	// consume hardware-specific image selection without a provider coupling.
+	HardwareInstallerImageAnnotation = "hardware.tinkerbell.org/installer-image"
 )
 
 var (
@@ -209,6 +216,13 @@ func (scope *machineReconcileScope) ensureHardware() (*tinkv1.Hardware, error) {
 	if scope.tinkerbellMachine.Status.TargetNamespace == "" {
 		scope.tinkerbellMachine.Status.TargetNamespace = hw.Namespace
 	}
+
+	// Mirror the Hardware's installer-image annotation into machine status
+	// on every reconcile so bootstrap providers consuming
+	// status.installerImage observe annotation set, change, and removal.
+	// An absent annotation is the normal case: the field is left empty and
+	// consumers treat that as "no override".
+	scope.tinkerbellMachine.Status.InstallerImage = hw.GetAnnotations()[HardwareInstallerImageAnnotation]
 
 	// In JIT watch mode, ensure there is a namespace-scoped informer cache
 	// watching Workflows and Jobs in the Hardware's namespace so that the

--- a/controller/machine/tinkerbellmachine_test.go
+++ b/controller/machine/tinkerbellmachine_test.go
@@ -64,6 +64,8 @@ type testOptions struct {
 	// Labels allow providing labels for the machine
 	Labels           map[string]string
 	HardwareAffinity *infrastructurev1.HardwareAffinity
+	// Annotations allow providing annotations for the machine
+	Annotations map[string]string
 }
 
 //nolint:unparam
@@ -222,6 +224,14 @@ func validHardware(name, uuid, ip string, options ...testOptions) *tinkv1.Hardwa
 			}
 
 			hw.Labels[k] = v
+		}
+
+		for k, v := range o.Annotations {
+			if hw.Annotations == nil {
+				hw.Annotations = map[string]string{}
+			}
+
+			hw.Annotations[k] = v
 		}
 	}
 
@@ -1909,4 +1919,113 @@ func findCondition(conditions []metav1.Condition, conditionType string) *metav1.
 	}
 
 	return nil
+}
+
+func Test_Machine_reconciliation_mirrors_hardware_installer_image(t *testing.T) {
+	t.Parallel()
+
+	installerImage := "factory.talos.dev/installer/376567988ad370138ad8b2698212367b0c98777a8994c8bf0eb2bdd1f4d3bd11:v1.14.0"
+
+	tests := []struct {
+		name string
+		// annotations placed on the Hardware fixture
+		hardwareAnnotations map[string]string
+		// expected status.installerImage after the first reconcile
+		wantFirst string
+		// annotations on the Hardware for the second reconcile (nil: no second reconcile)
+		hardwareAnnotationsSecond map[string]string
+		// expected status.installerImage after the second reconcile
+		wantSecond string
+	}{
+		{
+			name:                      "annotation_set_mirrors_image",
+			hardwareAnnotations:       map[string]string{machine.HardwareInstallerImageAnnotation: installerImage},
+			wantFirst:                 installerImage,
+			hardwareAnnotationsSecond: nil,
+			wantSecond:                "",
+		},
+		{
+			name:                      "annotation_absent_leaves_status_empty",
+			hardwareAnnotations:       nil,
+			wantFirst:                 "",
+			hardwareAnnotationsSecond: nil,
+			wantSecond:                "",
+		},
+		{
+			name:                      "annotation_removed_clears_status",
+			hardwareAnnotations:       map[string]string{machine.HardwareInstallerImageAnnotation: installerImage},
+			wantFirst:                 installerImage,
+			hardwareAnnotationsSecond: map[string]string{},
+			wantSecond:                "",
+		},
+		{
+			name: "annotation_changed_updates_status",
+			hardwareAnnotations: map[string]string{
+				machine.HardwareInstallerImageAnnotation: "factory.talos.dev/installer/first:v1.14.0",
+			},
+			wantFirst: "factory.talos.dev/installer/first:v1.14.0",
+			hardwareAnnotationsSecond: map[string]string{
+				machine.HardwareInstallerImageAnnotation: "factory.talos.dev/installer/second:v1.15.0",
+			},
+			wantSecond: "factory.talos.dev/installer/second:v1.15.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			g := NewWithT(t)
+
+			hardwareUUID := uuid.New().String()
+
+			hw := validHardware(hardwareName, hardwareUUID, hardwareIP, testOptions{
+				Annotations: tt.hardwareAnnotations,
+			})
+			if tt.hardwareAnnotations == nil {
+				hw.Annotations = nil
+			}
+
+			objects := []runtime.Object{
+				validTinkerbellMachine(tinkerbellMachineName, clusterNamespace, machineName, hardwareUUID),
+				validCluster(clusterName, clusterNamespace),
+				validTinkerbellCluster(clusterName, clusterNamespace),
+				hw,
+				validMachine(machineName, clusterNamespace, clusterName),
+				validSecret(machineName, clusterNamespace),
+			}
+
+			client := kubernetesClientWithObjects(t, objects)
+
+			_, err := reconcileMachineWithClient(client, tinkerbellMachineName, clusterNamespace)
+			g.Expect(err).NotTo(HaveOccurred(), "Unexpected reconciliation error")
+
+			ctx := context.Background()
+
+			updatedMachine := &infrastructurev1.TinkerbellMachine{}
+			machineNamespacedName := types.NamespacedName{Name: tinkerbellMachineName, Namespace: clusterNamespace}
+			g.Expect(client.Get(ctx, machineNamespacedName, updatedMachine)).To(Succeed())
+			g.Expect(updatedMachine.Status.InstallerImage).To(Equal(tt.wantFirst),
+				"status.installerImage after first reconcile")
+
+			if tt.hardwareAnnotationsSecond == nil {
+				return
+			}
+
+			// Mutate the Hardware annotations and reconcile again; the mirror
+			// must track set, change, and removal on every reconcile.
+			hardwareNamespacedName := types.NamespacedName{Name: hardwareName, Namespace: clusterNamespace}
+			updatedHardware := &tinkv1.Hardware{}
+			g.Expect(client.Get(ctx, hardwareNamespacedName, updatedHardware)).To(Succeed())
+			updatedHardware.Annotations = tt.hardwareAnnotationsSecond
+			g.Expect(client.Update(ctx, updatedHardware)).To(Succeed())
+
+			_, err = reconcileMachineWithClient(client, tinkerbellMachineName, clusterNamespace)
+			g.Expect(err).NotTo(HaveOccurred(), "Unexpected second reconciliation error")
+
+			g.Expect(client.Get(ctx, machineNamespacedName, updatedMachine)).To(Succeed())
+			g.Expect(updatedMachine.Status.InstallerImage).To(Equal(tt.wantSecond),
+				"status.installerImage after second reconcile")
+		})
+	}
 }


### PR DESCRIPTION
## What

Mirror the `hardware.tinkerbell.org/installer-image` annotation from the Hardware bound to a TinkerbellMachine into a new `TinkerbellMachine.status.installerImage` field, on every reconcile.

## Why

An infrastructure provider often knows which installer image a machine should boot. For Talos that knowledge is concrete: the Image Factory resolves a schematic from the machine's actual hardware, so a node with NVMe storage gets an installer carrying NVMe tooling. CAPT already owns the Hardware binding, so it is the natural publisher — but until now there was nowhere for that decision to go, and bootstrap providers had no generic way to read it.

The consumer side already exists: cluster-api-bootstrap-provider-talos v0.7.6 ([sidero-community/cluster-api-bootstrap-provider-talos@494dd22](https://github.com/sidero-community/cluster-api-bootstrap-provider-talos/commit/494dd22)) reads `status.installerImage` from the referenced InfraMachine via unstructured access (no provider import) and injects it as `machine.install.image`, ahead of the user's strategic patches, folding it into the bootstrap data secret's config hash. Any provider publishing the same field behaves identically. Today no infrastructure provider populates it, so the handoff is inert; this PR gives it a producer.

## Design

- **Annotation on Hardware, not a new spec field.** The image is per-physical-machine knowledge; TinkerbellMachineTemplate is shared per cluster. This follows the existing per-Hardware override precedent (`hardware.tinkerbell.org/capt-template-override`).
- **Status, not spec.** Matches what CABPT reads; status survives `clusterctl move` and cannot fight the template.
- **Mirror semantics.** Set, change, and removal of the annotation are all reflected on the next reconcile. An absent annotation is the normal case: the field stays empty and consumers treat empty as "no override" — no error, no condition, no requeue.
- No new RBAC, no watches on Hardware changes (the field converges on the next natural reconcile; Hardware already drives machine reconciliation).

## Testing

Table-driven coverage of the four behaviors (annotation set mirrors the image; absent leaves status empty; removed clears status; changed updates status), using the existing fake-client reconciliation harness. `make generate` (CRD carries the new optional status field), `make lint`, and the full test suite pass.

## Downstream context

Tracked as [polarsquad/knr-ops#156](https://github.com/polarsquad/knr-ops/issues/156) (single-node Talos management cluster on Tinkerbell, where the installer image must come from hardware knowledge rather than a hand-maintained pin).
